### PR TITLE
remove obsolete commands

### DIFF
--- a/dotnu/mod.nu
+++ b/dotnu/mod.nu
@@ -1,10 +1,7 @@
 export use commands.nu [
     dependencies
     filter-commands-with-no-tests
-    parse-docstrings
-    update-docstring-examples
     set-x
-    generate-nupm-tests
     generate-numd
     extract-command-code
     module-commands-code-to-record


### PR DESCRIPTION
Because of added support for `@examples` https://github.com/nushell/nushell/pull/14906
current fragile implementation becomes obsolete. So I remove the according commands to clean code. 