### PR TITLE
ci: add GitHub Actions workflow for automated testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Nushell
+        uses: hustcer/setup-nu@v3
+        with:
+          version: "*"
+
+      - name: Install nutest
+        run: git clone https://github.com/vyadh/nutest.git ../nutest
+
+      - name: Run tests
+        run: nu tools.nu testing --json
+
+      - name: Show diff of changed files
+        if: always()
+        run: git diff


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow mirroring numd's setup
- Run tests on push/PR to main branch
- Test on both Ubuntu and Windows platforms

## Test plan
- [ ] CI workflow triggers on PR
- [ ] Tests pass on Ubuntu
- [ ] Tests pass on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)