### PR TITLE
fix: Windows glob path compatibility in tests

### DIFF
--- a/tools.nu
+++ b/tools.nu
@@ -82,7 +82,7 @@ def 'test-dependencies' [] {
 
     # Run the command and get its source code
     let command_src = {
-        glob ([tests assets b *] | path join)
+        glob ([tests assets b *] | path join | into glob)
         | dependencies ...$in
         | to yaml
     }

--- a/tools.nu
+++ b/tools.nu
@@ -82,7 +82,11 @@ def 'test-dependencies' [] {
 
     # Run the command and get its source code
     let command_src = {
-        glob ([tests assets b *] | path join | into glob)
+        glob (
+            [tests assets b *]
+            | path join
+            | str replace -a '\' '/' # fix for windows
+        )
         | dependencies ...$in
         | to yaml
     }
@@ -123,7 +127,11 @@ def 'test-dependencies-keep_builtins' [] {
 
     # Run the command and get its source code
     let command_src = {
-        glob ([tests assets b *] | path join)
+        glob (
+            [tests assets b *]
+            | path join
+            | str replace -a '\' '/' # fix for windows
+        )
         | dependencies ...$in --keep-builtins
         | to yaml
     }


### PR DESCRIPTION
## Summary
- Fix glob patterns failing on Windows due to backslash path separators
- `path join` on Windows produces `tests\assets\b\*` where backslashes are interpreted as escape characters in glob patterns
- Replace backslashes with forward slashes before passing to glob command

## Test plan
- [ ] Verify Windows CI tests pass
- [ ] Verify Linux/macOS CI tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)