### PR TITLE
fix: resolve infinite loop in dependencies command

### DIFF
--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -476,9 +476,13 @@ export def list-module-commands [
     # str index-of fails when identical lines exist (e.g. multiple '@example' lines)
     let lines_pos = $script_content
     | lines
-    | reduce -f {offset: 0 lines: []} {|line acc|
+    | reduce --fold {offset: 0 lines: []} {|line acc|
         let entry = {line: $line start: $acc.offset}
-        {offset: ($acc.offset + ($line | str length -b) + 1) lines: ($acc.lines | append $entry)}
+
+        {
+            offset: ($acc.offset + ($line | str length -b) + 1)
+            lines: ($acc.lines | append $entry)
+        }
     }
     | get lines
 

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -29,14 +29,15 @@ export def 'dependencies' [
     | uniq-by caller callee
 }
 
-# Filter commands after `dotnu dependencies` that aren't used by any other command containing `test` in its name.
+# Filter commands after `dotnu dependencies` that aren't used by any test command.
+# Test commands are detected by: name contains 'test' OR file matches 'test*.nu'
 @example '' {
     dependencies ...(glob tests/assets/module-say/say/*.nu) | filter-commands-with-no-tests
 } --result [{caller: hello filename_of_caller: "hello.nu"} {caller: question filename_of_caller: "ask.nu"} {caller: say filename_of_caller: "mod.nu"}]
 export def 'filter-commands-with-no-tests' [] {
     let input = $in
     let covered_with_tests = $input
-    | where caller =~ 'test'
+    | where caller =~ 'test' or filename_of_caller =~ '^test.*\.nu$'
     | get callee
     | compact
     | uniq
@@ -44,7 +45,7 @@ export def 'filter-commands-with-no-tests' [] {
     $input
     | reject callee step
     | uniq-by caller
-    | where caller !~ 'test'
+    | where caller !~ 'test' and filename_of_caller !~ '^test.*\.nu$'
     | where caller not-in $covered_with_tests
 }
 

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -205,6 +205,16 @@ def "dependencies handles module-say example" [] {
     assert (($say_calls | length) > 0)
 }
 
+@test
+def "dependencies handles files with @example containing same-file calls" [] {
+    # This tests the fix for infinite loop when @example blocks call commands defined in the same file
+    let result = dependencies dotnu/commands.nu
+
+    # Should complete without hanging and have no self-references
+    let self_refs = $result | where caller == callee
+    assert (($self_refs | length) == 0) "should have no self-referential calls"
+}
+
 # =============================================================================
 # Tests for filter-commands-with-no-tests
 # =============================================================================


### PR DESCRIPTION
## Summary

- Fix infinite loop bug in `dependencies` command when analyzing files with `@example` attributes containing same-file command calls
- Fix `filter-commands-with-no-tests` to detect tests by filename pattern (`test*.nu`) in addition to name pattern

## Root Cause

The `dependencies` command hung because:
1. `str index-of` returned the same position for identical lines (e.g., multiple `@example '' {` lines)
2. The exact-position join failed since definition marker positions (line starts) don't match AST token positions (expression starts)

This caused tokens inside `@example` blocks to be attributed to the wrong command, creating self-referential cycles like `dependencies → dependencies`.

## Changes

- Calculate cumulative byte positions for each line instead of using `str index-of`
- Use range-based token assignment instead of exact-position join
- Add integration test for the @example self-reference case
- Improve test detection in `filter-commands-with-no-tests` to recognize `test*.nu` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)