### PR TITLE
Add tests for previously untested commands and fix @example filter bug

### DIFF
--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -530,6 +530,7 @@ export def list-module-commands [
     | where caller != null
 
     let defs_without_calls = $defined_defs
+    | where caller !~ '^@'  # exclude attribute decorators from output
     | select caller filename_of_caller
     | where caller not-in ($calls.caller | uniq)
     | insert callee null


### PR DESCRIPTION
## Summary
- Add 17 new tests covering previously untested commands: `set-x`, `extract-command-code`, `list-exported-commands`, `embeds-update`, `embeds-setup`, `execute-and-parse-results`, `module-commands-code-to-record`, and helper functions
- Fix `filter-commands-with-no-tests` to exclude `@example` and other attribute decorators from output (they were incorrectly flagged as commands without tests)

## Test plan
- [x] New tests pass locally
- [ ] Verify CI passes
- [ ] Test `filter-commands-with-no-tests` no longer shows `@example` decorators

🤖 Generated with [Claude Code](https://claude.com/claude-code)