### PR TITLE
fix: use AST to detect attributes, preventing false positives in strings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**dotnu** is a toolkit for Nushell module developers providing:
+- **Literate programming**: Embed real command output in scripts as `# =>` annotations
+- **Dependency analysis**: Analyze call chains between commands using AST parsing
+- **Script profiling**: Measure execution timing of script blocks with `set-x`
+
+## Commands
+
+```bash
+# Run all tests (unit + integration)
+nu toolkit.nu test
+
+# Run unit tests only (uses nutest framework)
+nu toolkit.nu test-unit
+
+# Run integration tests only
+nu toolkit.nu test-integration
+
+# Release (bumps version in nupm.nuon and README.md, commits, tags, pushes)
+nu toolkit.nu release           # patch bump
+nu toolkit.nu release --minor   # minor bump
+nu toolkit.nu release --major   # major bump
+```
+
+## Architecture
+
+### Module Structure
+
+```
+dotnu/
+├── mod.nu          # Public API exports (13 commands)
+└── commands.nu     # All implementation (~800 lines)
+```
+
+**mod.nu** exports these public commands:
+- `dependencies` - Analyze command call chains
+- `extract-command-code` - Extract command with its dependencies
+- `filter-commands-with-no-tests` - Find untested commands
+- `list-exported-commands` - List module's exported commands
+- `embeds-*` / `embed-add` - Literate programming tools
+- `set-x` / `generate-numd` - Script profiling
+
+### Key Implementation Details
+
+**AST-based attribute detection** (`commands.nu:499-508`): Uses `nu --ide-ast` to detect `@test`, `@example` decorators accurately, preventing false positives from `@something` inside strings.
+
+**Dependency tracking algorithm**:
+1. Line-based parsing finds `def` statements with byte offsets
+2. AST parsing identifies attribute decorators
+3. Range-based lookup associates calls with defining scopes
+4. `generate` streams recursive dependency chains
+
+### Test Structure
+
+```
+tests/
+├── test_commands.nu    # Unit tests (~250 cases, nutest framework)
+├── assets/             # Test fixtures
+│   ├── b/              # Module dependency examples
+│   └── module-say/     # Real-world module example
+└── output-yaml/        # Integration test outputs
+```
+
+Unit tests use `@test` decorator and `assert` from `std/testing`.
+
+## Dependencies
+
+- **nutest**: Testing framework (cloned in CI from https://github.com/vyadh/nutest.git)
+- **numd**: Optional, for markdown integration
+- **std library**: Uses `std/iter` (scan) and `std/testing` (assert)
+
+## Conventions
+
+- Public commands: kebab-case, exported in mod.nu
+- Internal helpers: kebab-case, not exported
+- Test detection: commands named `test*` or in `test*.nu` files
+- Documentation: `@example` decorators with `--result` for expected output

--- a/README.md
+++ b/README.md
@@ -222,7 +222,8 @@ dotnu dependencies --help
 
 ```nushell
 dotnu filter-commands-with-no-tests --help
-# => Filter commands after `dotnu dependencies` that aren't used by any other command containing `test` in its name.
+# => Filter commands after `dotnu dependencies` that aren't used by any test command.
+# => Test commands are detected by: name contains 'test' OR file matches 'test*.nu'
 # =>
 # => Usage:
 # =>   > filter-commands-with-no-tests

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -494,7 +494,9 @@ export def list-module-commands [
                 | extract-command-name
                 | replace-main-with-module-name $module_path
             }
-            $l if $l =~ '^@\w+' => ($l | parse -r '^(?<attr>@\w+)' | get 0.attr)
+            # Match valid attribute syntax: @word, @word external, @word 'str' {...}, etc.
+            # Excludes fake matches like "@fake is a sentence" inside raw strings
+            $l if $l =~ '^@\w+(\s+(external|[''"{\[]|r#)|\s*$)' => ($l | parse -r '^(?<attr>@\w+)' | get 0.attr)
             _ => null
         }
     }

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -494,7 +494,7 @@ export def list-module-commands [
                 | extract-command-name
                 | replace-main-with-module-name $module_path
             }
-            $l if $l =~ '^@example' => '@example'
+            $l if $l =~ '^@\w+' => ($l | parse -r '^(?<attr>@\w+)' | get 0.attr)
             _ => null
         }
     }
@@ -518,7 +518,7 @@ export def list-module-commands [
             $token | insert caller $def.caller | insert filename_of_caller $def.filename_of_caller
         }
     }
-    | where caller != '@example'
+    | where caller != null and caller !~ '^@'  # exclude tokens inside attribute blocks
     | where shape in ['shape_internalcall' 'shape_external']
     | if $keep_builtins { } else {
         where content not-in (
@@ -527,7 +527,6 @@ export def list-module-commands [
     }
     | select caller content filename_of_caller
     | rename --column {content: callee}
-    | where caller != null
 
     let defs_without_calls = $defined_defs
     | where caller !~ '^@'  # exclude attribute decorators from output

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -494,9 +494,7 @@ export def list-module-commands [
                 | extract-command-name
                 | replace-main-with-module-name $module_path
             }
-            # Match valid attribute syntax: @word, @word external, @word 'str' {...}, etc.
-            # Excludes fake matches like "@fake is a sentence" inside raw strings
-            $l if $l =~ '^@\w+(\s+(external|[''"{\[]|r#)|\s*$)' => ($l | parse -r '^(?<attr>@\w+)' | get 0.attr)
+            $l if $l =~ '^@\w+' => ($l | parse -r '^(?<attr>@\w+)' | get 0.attr)
             _ => null
         }
     }

--- a/tests/assets/attribute-edge-cases.nu
+++ b/tests/assets/attribute-edge-cases.nu
@@ -14,6 +14,14 @@ export def 'email-formatter' [] {
     $template | str replace '@support' 'support@example.com'
 }
 
+# Raw string with @fake at line start - should NOT be treated as attribute
+export def 'raw-string-command' [] {
+    r###'
+@fake is a fabricated raw string
+'###
+    email-formatter  # this call SHOULD appear
+}
+
 # Regular command for dependency testing
 export def 'main-command' [] {
     email-formatter

--- a/tests/assets/attribute-edge-cases.nu
+++ b/tests/assets/attribute-edge-cases.nu
@@ -1,0 +1,20 @@
+# Test file for attribute decorator edge cases
+
+# Multi-word attribute with closure - calls inside should be excluded
+@example 'demo' {
+    email-formatter  # this call should NOT appear in dependencies
+}
+export def 'decorated-command' [] {
+    email-formatter  # this call SHOULD appear
+}
+
+# This command has @something in a string - should NOT be treated as attribute
+export def 'email-formatter' [] {
+    let template = "Contact us @support or @help for assistance"
+    $template | str replace '@support' 'support@example.com'
+}
+
+# Regular command for dependency testing
+export def 'main-command' [] {
+    email-formatter
+}

--- a/tests/assets/attribute-edge-cases.nu
+++ b/tests/assets/attribute-edge-cases.nu
@@ -26,3 +26,12 @@ export def 'raw-string-command' [] {
 export def 'main-command' [] {
     email-formatter
 }
+
+# Raw string with @example 'text' that MATCHES attribute regex - should NOT be treated as attribute
+# This is the tricky case: the line looks exactly like a real attribute decorator
+export def 'tricky-raw-string-command' [] {
+    r###'
+@example 'this line matches attribute regex but is inside raw string!'
+'###
+    email-formatter  # this call SHOULD appear - bug if it doesn't!
+}

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -257,6 +257,21 @@ def "dependencies ignores @fake inside raw strings" [] {
     assert ('email-formatter' in $raw_calls.callee) "raw-string-command should call email-formatter"
 }
 
+@test
+def "dependencies ignores @example inside raw strings even when matching attribute regex" [] {
+    # This tests the tricky case: @example 'text' inside raw string looks exactly like
+    # a real attribute decorator and matches the regex, but should NOT be treated as one
+    let result = list-module-commands tests/assets/attribute-edge-cases.nu
+
+    # The fake @example inside raw string should NOT appear as a caller
+    let example_callers = $result | where caller == '@example'
+    assert (($example_callers | length) == 0) "@example inside raw string should not be a caller"
+
+    # tricky-raw-string-command should call email-formatter (call after the raw string)
+    let tricky_calls = $result | where caller == 'tricky-raw-string-command'
+    assert ('email-formatter' in $tricky_calls.callee) "tricky-raw-string-command should call email-formatter"
+}
+
 # =============================================================================
 # Tests for filter-commands-with-no-tests
 # =============================================================================

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -245,6 +245,18 @@ def "dependencies ignores @something inside strings" [] {
     assert ('email-formatter' in $main_calls.callee) "main-command should call email-formatter"
 }
 
+@test
+def "dependencies ignores @fake inside raw strings" [] {
+    let result = list-module-commands tests/assets/attribute-edge-cases.nu
+
+    # @fake should NOT appear as a caller
+    assert ('@fake' not-in $result.caller) "@fake inside raw string should not be a caller"
+
+    # raw-string-command should call email-formatter (call after raw string)
+    let raw_calls = $result | where caller == 'raw-string-command'
+    assert ('email-formatter' in $raw_calls.callee) "raw-string-command should call email-formatter"
+}
+
 # =============================================================================
 # Tests for filter-commands-with-no-tests
 # =============================================================================


### PR DESCRIPTION
## Summary

- Use AST parsing to detect `@attribute` decorators accurately instead of line-based regex
- Cache AST tokens to avoid parsing the file twice (perf improvement)
- Exclude calls inside attribute blocks (e.g., `@example { some-call }`) from dependencies
- Add comprehensive tests for edge cases: `@something` inside strings, raw strings, and attribute closures

## Changes

- **dotnu/commands.nu**: Refactored `list-module-commands` with two-phase parsing:
  1. Line-based parsing for `def` statements (need byte offsets)
  2. AST-based parsing for attributes (prevents false positives)
- **tests/assets/attribute-edge-cases.nu**: New test fixture covering tricky cases
- **tests/test_commands.nu**: 4 new tests for attribute edge cases
- **README.md**: Clarified `filter-commands-with-no-tests` detection logic
- **CLAUDE.md**: Added Claude Code guidance document

## Test plan

- [x] All unit tests pass (`nu toolkit.nu test-unit`)
- [x] Edge cases verified: `@example` in raw strings no longer creates false callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)