### PR TITLE
fix: use AST to detect attributes, preventing false positives in strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
         shell: bash
         run: nu toolkit.nu test --json
 
+      - name: Show test failures (Windows debug)
+        if: always() && runner.os == 'Windows'
+        shell: bash
+        run: |
+          nu -c "use ../nutest/nutest; nutest run-tests --path tests/ --match-suites 'test_commands' --returns table | where result == 'FAIL' | first 5 | select suite test output | to md" || true
+
       - name: Show diff of changed files
         if: always()
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,12 @@ jobs:
         shell: bash
         run: nu toolkit.nu test --json
 
-      - name: Show test failures (Windows debug)
-        if: always() && runner.os == 'Windows'
-        shell: bash
-        run: |
-          nu -c "use ../nutest/nutest; nutest run-tests --path tests/ --match-suites 'test_commands' --returns table | where result == 'FAIL' | first 5 | select suite test output | to md" || true
+      # Debug step disabled - runs tests twice, adds ~15min on Windows
+      # - name: Show test failures (Windows debug)
+      #   if: always() && runner.os == 'Windows'
+      #   shell: bash
+      #   run: |
+      #     nu -c "use ../nutest/nutest; nutest run-tests --path tests/ --match-suites 'test_commands' --returns table | where result == 'FAIL' | first 5 | select suite test output | to md" || true
 
       - name: Show diff of changed files
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,10 @@ jobs:
         run: git clone https://github.com/vyadh/nutest.git ../nutest
 
       - name: Run tests
+        shell: bash
         run: nu toolkit.nu test --json
 
       - name: Show diff of changed files
         if: always()
+        shell: bash
         run: git diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           version: "*"
 
       - name: Install nutest
+        shell: bash
         run: git clone https://github.com/vyadh/nutest.git ../nutest
 
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ md_backups
 zzz_md_backups
 .claude/
 todo/
+misc/logs_53154114552

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**dotnu** is a toolkit for Nushell module developers providing:
+- **Literate programming**: Embed real command output in scripts as `# =>` annotations
+- **Dependency analysis**: Analyze call chains between commands using AST parsing
+- **Script profiling**: Measure execution timing of script blocks with `set-x`
+
+## Commands
+
+```bash
+# Run all tests (unit + integration)
+nu toolkit.nu test
+
+# Run unit tests only (uses nutest framework)
+nu toolkit.nu test-unit
+
+# Run integration tests only
+nu toolkit.nu test-integration
+
+# Release (bumps version in nupm.nuon and README.md, commits, tags, pushes)
+nu toolkit.nu release           # patch bump
+nu toolkit.nu release --minor   # minor bump
+nu toolkit.nu release --major   # major bump
+```
+
+## Architecture
+
+### Module Structure
+
+```
+dotnu/
+├── mod.nu          # Public API exports (13 commands)
+└── commands.nu     # All implementation (~800 lines)
+```
+
+**mod.nu** exports these public commands:
+- `dependencies` - Analyze command call chains
+- `extract-command-code` - Extract command with its dependencies
+- `filter-commands-with-no-tests` - Find untested commands
+- `list-exported-commands` - List module's exported commands
+- `embeds-*` / `embed-add` - Literate programming tools
+- `set-x` / `generate-numd` - Script profiling
+
+### Key Implementation Details
+
+**AST-based attribute detection** (`commands.nu:499-508`): Uses `nu --ide-ast` to detect `@test`, `@example` decorators accurately, preventing false positives from `@something` inside strings.
+
+**Dependency tracking algorithm**:
+1. Line-based parsing finds `def` statements with byte offsets
+2. AST parsing identifies attribute decorators
+3. Range-based lookup associates calls with defining scopes
+4. `generate` streams recursive dependency chains
+
+### Test Structure
+
+```
+tests/
+├── test_commands.nu    # Unit tests (~250 cases, nutest framework)
+├── assets/             # Test fixtures
+│   ├── b/              # Module dependency examples
+│   └── module-say/     # Real-world module example
+└── output-yaml/        # Integration test outputs
+```
+
+Unit tests use `@test` decorator and `assert` from `std/testing`.
+
+## Dependencies
+
+- **nutest**: Testing framework (cloned in CI from https://github.com/vyadh/nutest.git)
+- **numd**: Optional, for markdown integration
+- **std library**: Uses `std/iter` (scan) and `std/testing` (assert)
+
+## Conventions
+
+- Public commands: kebab-case, exported in mod.nu
+- Internal helpers: kebab-case, not exported
+- Test detection: commands named `test*` or in `test*.nu` files
+- Documentation: `@example` decorators with `--result` for expected output

--- a/README.md
+++ b/README.md
@@ -222,7 +222,8 @@ dotnu dependencies --help
 
 ```nushell
 dotnu filter-commands-with-no-tests --help
-# => Filter commands after `dotnu dependencies` that aren't used by any other command containing `test` in its name.
+# => Filter commands after `dotnu dependencies` that aren't used by any test command.
+# => Test commands are detected by: name contains 'test' OR file matches 'test*.nu'
 # =>
 # => Usage:
 # =>   > filter-commands-with-no-tests

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -494,7 +494,9 @@ export def list-module-commands [
                 | extract-command-name
                 | replace-main-with-module-name $module_path
             }
-            $l if $l =~ '^@\w+' => ($l | parse -r '^(?<attr>@\w+)' | get 0.attr)
+            # Match valid attribute syntax: @word, @word external, @word 'str' {...}, etc.
+            # Excludes fake matches like "@fake is a sentence" inside raw strings
+            $l if $l =~ '^@\w+(\s+(external|[''"{\[]|r#)|\s*$)' => ($l | parse -r '^(?<attr>@\w+)' | get 0.attr)
             _ => null
         }
     }

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -494,7 +494,7 @@ export def list-module-commands [
                 | extract-command-name
                 | replace-main-with-module-name $module_path
             }
-            $l if $l =~ '^@example' => '@example'
+            $l if $l =~ '^@\w+' => ($l | parse -r '^(?<attr>@\w+)' | get 0.attr)
             _ => null
         }
     }
@@ -518,7 +518,7 @@ export def list-module-commands [
             $token | insert caller $def.caller | insert filename_of_caller $def.filename_of_caller
         }
     }
-    | where caller != '@example'
+    | where caller != null and caller !~ '^@'  # exclude tokens inside attribute blocks
     | where shape in ['shape_internalcall' 'shape_external']
     | if $keep_builtins { } else {
         where content not-in (
@@ -527,7 +527,6 @@ export def list-module-commands [
     }
     | select caller content filename_of_caller
     | rename --column {content: callee}
-    | where caller != null
 
     let defs_without_calls = $defined_defs
     | where caller !~ '^@'  # exclude attribute decorators from output

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -189,6 +189,7 @@ export def 'embeds-update' [
     }
 
     let script = if $input == null { open $file } else { $input }
+    | if $nu.os-info.family == windows { str replace --all (char crlf) "\n" } else { }
     | embeds-remove
 
     let results = execute-and-parse-results $script --script_path=$file
@@ -749,10 +750,12 @@ export def find-capture-points [] {
 
 # Removes annotation lines starting with "# => " from the script
 export def embeds-remove [] {
-    str replace -a "\n\n# => " "\n# => "
+    if $nu.os-info.family == windows { str replace --all (char crlf) "\n" } else { }
+    | str replace -a "\n\n# => " "\n# => "
     | lines
     | where not ($it starts-with "# => ")
-    | to text
+    | str join "\n"
+    | $in + "\n"  # Explicit LF with trailing newline for Windows compatibility
 }
 
 export def capture-marker [

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -717,6 +717,7 @@ export def execute-and-parse-results [
     | str replace 'capture-marker' $"'(capture-marker)'"
     | str replace '(capture-marker --close)' $"'(capture-marker --close)'"
     | str replace 'comment-hash-colon' (comment-hash-colon --source-code)
+    | str replace 'to text' "str join \"\\n\"" # Windows CRLF fix
 
     let script_updated = $script
     | lines
@@ -727,7 +728,7 @@ export def execute-and-parse-results [
         } else { }
     }
     | prepend $embed_in_script_src
-    | to text
+    | str join "\n"
 
     if $script_path != null { $script_path | path dirname | cd $in }
 

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -142,7 +142,8 @@ export def 'extract-command-code' [
     | prepend $'source ($module_path)'
     | append $dotnu_vars_delim
     | append $extracted_command.1
-    | to text
+    | str join "\n"
+    | $in + "\n"
     | if $echo {
         return $in
     } else {

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -755,7 +755,7 @@ export def embeds-remove [] {
     | to text
 }
 
-def capture-marker [
+export def capture-marker [
     --close
 ] {
     if not $close {

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -494,9 +494,7 @@ export def list-module-commands [
                 | extract-command-name
                 | replace-main-with-module-name $module_path
             }
-            # Match valid attribute syntax: @word, @word external, @word 'str' {...}, etc.
-            # Excludes fake matches like "@fake is a sentence" inside raw strings
-            $l if $l =~ '^@\w+(\s+(external|[''"{\[]|r#)|\s*$)' => ($l | parse -r '^(?<attr>@\w+)' | get 0.attr)
+            $l if $l =~ '^@\w+' => ($l | parse -r '^(?<attr>@\w+)' | get 0.attr)
             _ => null
         }
     }

--- a/misc/ci_debug.md
+++ b/misc/ci_debug.md
@@ -100,13 +100,28 @@ User pulled latest nutest. Recent changes include:
 - `d42e76c` - don't display PASS by default
 - `2267c73` - account for 0.109.2+ assert/error format changes
 
-**Testing if updated nutest fixes Windows CI.**
+## RESOLVED: Windows CI now completes (but very slow)
 
-## Next steps if still failing
+**Commit `07f5def` and later runs complete on Windows.**
 
-1. **Try single-threaded:** Check if nutest has option to disable `par-each`
-2. **Simplify test file:** Create minimal test file to isolate issue
-3. **Binary search:** Disable half the tests to find which one hangs
+### Findings:
+1. **Extreme slowness**: Unit tests take ~14.5 minutes on Windows vs ~3 seconds on Linux (~300x slower)
+2. **All 46 unit tests fail**: Due to CRLF issues in assertions
+3. **Integration tests work**: But `embeds-update` output has empty `# =>` lines
+
+### Git diff warnings:
+```
+warning: in the working copy of 'tests/output-yaml/dependencies.yaml', LF will be replaced by CRLF
+```
+
+### Root cause of test failures:
+The `embeds-update` integration test produces different output on Windows - missing the embedded results.
+This suggests the subprocess execution or output parsing is affected by CRLF.
+
+## Remaining issues
+
+1. **Performance**: Investigate why Windows is 300x slower (likely `par-each` subprocess overhead)
+2. **CRLF in embeds**: Fix `execute-and-parse-results` to handle Windows line endings in subprocess output
 
 ## Files involved
 - `.github/workflows/ci.yml` - CI configuration

--- a/misc/ci_debug.md
+++ b/misc/ci_debug.md
@@ -1,0 +1,107 @@
+# Windows CI Debug Investigation
+
+## Problem
+Windows CI hangs indefinitely on `nu toolkit.nu test --json`
+
+## Environment
+- Runner: `windows-latest`
+- Nushell: latest (`hustcer/setup-nu@v3`)
+- nutest: cloned from `https://github.com/vyadh/nutest.git`
+
+## Timeline of fixes attempted
+
+### 1. Git clone hang (FIXED)
+**Symptom:** CI stuck on `git clone https://github.com/vyadh/nutest.git`
+**Cause:** PowerShell triggers Windows Credential Manager prompts
+**Fix:** Added `shell: bash` to the step
+
+### 2. Test command hang (FIXED)
+**Symptom:** CI stuck on `nu toolkit.nu test --json`
+**Cause:** Same PowerShell issue
+**Fix:** Added `shell: bash` to all CI steps
+
+### 3. nutest run-tests hang (CURRENT)
+**Symptom:** Hangs after `nutest run-tests --path tests/ --match-suites 'test_commands'`
+**Debug output shows:**
+```
+DEBUG: starting tests
+DEBUG: starting unit tests
+DEBUG: importing nutest
+DEBUG: nutest imported
+DEBUG: calling nutest run-tests with display=nothing
+[hangs here]
+```
+
+## Key observation
+**nutest works on numd's Windows CI but hangs on dotnu's**
+
+This suggests the issue is specific to dotnu's tests, not nutest itself.
+
+## Differences between dotnu and numd
+
+### 1. `to text` usage
+- **dotnu:** Uses `to text` 14 times in `commands.nu`
+- **numd:** Unknown, but nutest itself doesn't use `to text`
+- **Concern:** `to text` produces `\r\n` on Windows, could cause CRLF issues
+
+### 2. Test file differences
+- **dotnu:** `tests/test_commands.nu` (~250 test cases)
+- **numd:** Different test structure
+
+### 3. Module imports
+dotnu's `toolkit.nu` line 1-2:
+```nushell
+use ('dotnu' | path join 'commands.nu') *
+use dotnu
+```
+This imports `commands.nu` which has heavy `to text` usage.
+
+## CRLF fix attempted
+Changed in `commands.nu`:
+- Line 720: Added `str replace 'to text' "str join \"\\n\""` for serialized closure
+- Line 730: Changed `| to text` → `| str join "\n"`
+
+This fix ensures subprocess scripts use `\n` line endings, but **did not resolve the hang**.
+
+## Hypotheses to investigate
+
+### H1: Test file parsing issue
+Something in `tests/test_commands.nu` causes nutest to hang during discovery/parsing on Windows.
+
+### H2: Module loading issue
+The `use ('dotnu' | path join 'commands.nu') *` dynamic path might behave differently on Windows.
+
+### H3: Specific test hangs
+One of the 46 unit tests might hang when executed on Windows (subprocess, file path, etc.)
+
+## Key finding: nutest subprocess discovery
+
+nutest's `discover.nu` (line 57) spawns a subprocess to discover tests:
+```nushell
+let result = (^$nu.current-exe --no-config-file --commands $query)
+```
+
+Where `$query` is:
+```nushell
+source ($file); scope commands | where ...
+```
+
+When this sources `tests/test_commands.nu`, it imports `../dotnu/commands.nu *`.
+
+**The hang likely occurs during:**
+1. Subprocess spawn on Windows
+2. Or parsing/loading `commands.nu` in that subprocess
+3. Or `par-each` (line 43) parallel discovery
+
+## Next steps
+
+1. **Add debug to test file:** Add `print -e` at top of `test_commands.nu` to see if source completes
+2. **Try single-threaded:** Check if nutest has option to disable `par-each`
+3. **Simplify test file:** Create minimal test file to isolate issue
+4. **Compare with numd:** numd's commands.nu (707 lines) vs dotnu (766 lines)
+
+## Files involved
+- `.github/workflows/ci.yml` - CI configuration
+- `toolkit.nu` - Test runner entry point
+- `dotnu/commands.nu` - Main implementation (uses `to text`)
+- `tests/test_commands.nu` - Unit tests

--- a/misc/ci_debug.md
+++ b/misc/ci_debug.md
@@ -120,8 +120,17 @@ This suggests the subprocess execution or output parsing is affected by CRLF.
 
 ## Remaining issues
 
-1. **Performance**: Investigate why Windows is 300x slower (likely `par-each` subprocess overhead)
-2. **CRLF in embeds**: Fix `execute-and-parse-results` to handle Windows line endings in subprocess output
+1. **Performance**: Windows unit tests take 14-40 minutes (vs 3 sec on Linux). High variability due to runner allocation.
+2. **All 46 tests fail**: Root cause unknown - need to capture actual error messages
+3. **CRLF in embeds**: Integration tests show missing `# =>` output lines on Windows
+
+## Windows runner variability
+
+Observed times for same test suite:
+- Run 1: ~14.5 minutes
+- Run 2: 39+ minutes (cancelled)
+
+This is normal for GitHub-hosted Windows runners - they can be 2-3x slower depending on VM allocation.
 
 ## Files involved
 - `.github/workflows/ci.yml` - CI configuration

--- a/misc/ci_debug.md
+++ b/misc/ci_debug.md
@@ -93,12 +93,20 @@ When this sources `tests/test_commands.nu`, it imports `../dotnu/commands.nu *`.
 2. Or parsing/loading `commands.nu` in that subprocess
 3. Or `par-each` (line 43) parallel discovery
 
-## Next steps
+## Update: Local nutest was outdated
 
-1. **Add debug to test file:** Add `print -e` at top of `test_commands.nu` to see if source completes
-2. **Try single-threaded:** Check if nutest has option to disable `par-each`
-3. **Simplify test file:** Create minimal test file to isolate issue
-4. **Compare with numd:** numd's commands.nu (707 lines) vs dotnu (766 lines)
+User pulled latest nutest. Recent changes include:
+- `287e74a` - bumped actions/checkout to v6
+- `d42e76c` - don't display PASS by default
+- `2267c73` - account for 0.109.2+ assert/error format changes
+
+**Testing if updated nutest fixes Windows CI.**
+
+## Next steps if still failing
+
+1. **Try single-threaded:** Check if nutest has option to disable `par-each`
+2. **Simplify test file:** Create minimal test file to isolate issue
+3. **Binary search:** Disable half the tests to find which one hangs
 
 ## Files involved
 - `.github/workflows/ci.yml` - CI configuration

--- a/misc/embed_debug.nu
+++ b/misc/embed_debug.nu
@@ -20,40 +20,50 @@ let embed_in_script = {
 
 print "1. Original closure source:"
 let orig_src = (view source $embed_in_script)
-print $"   Length: ($orig_src | str length)"
-print $"   Hex (first 200): ($orig_src | encode hex | str substring 0..200)"
+let orig_len = ($orig_src | str length)
+let orig_hex = ($orig_src | encode hex | str substring 0..200)
+print $"   Length: ($orig_len)"
+print $"   Hex \(first 200\): ($orig_hex)"
 print ""
 
 # Step 2: Apply the same replacements as execute-and-parse-results
 print "2. Applying str replace operations..."
 
 let src1 = $orig_src | 'def embed-in-script [] ' + $in
-print $"   After prepending 'def': length ($src1 | str length)"
+let src1_len = ($src1 | str length)
+print $"   After prepending 'def': length ($src1_len)"
 
 let marker_open = (capture-marker)
 let marker_close = (capture-marker --close)
-print $"   Marker open: ($marker_open | encode hex)"
-print $"   Marker close: ($marker_close | encode hex)"
+let marker_open_hex = ($marker_open | encode hex)
+let marker_close_hex = ($marker_close | encode hex)
+print $"   Marker open: ($marker_open_hex)"
+print $"   Marker close: ($marker_close_hex)"
 
 let src2 = $src1 | str replace 'capture-marker' $"'($marker_open)'"
-print $"   After replacing 'capture-marker': length ($src2 | str length)"
-let contains_marker = ($src2 | str contains ($marker_open))
+let src2_len = ($src2 | str length)
+let contains_marker = ($src2 | str contains $marker_open)
+print $"   After replacing 'capture-marker': length ($src2_len)"
 print $"   Contains marker in source: ($contains_marker)"
 
 let src3 = $src2 | str replace '(capture-marker --close)' $"'($marker_close)'"
-print $"   After replacing '(capture-marker --close)': length ($src3 | str length)"
+let src3_len = ($src3 | str length)
+print $"   After replacing '\(capture-marker --close\)': length ($src3_len)"
 
 let src4 = $src3 | str replace 'comment-hash-colon' (comment-hash-colon --source-code)
-print $"   After replacing 'comment-hash-colon': length ($src4 | str length)"
+let src4_len = ($src4 | str length)
+print $"   After replacing 'comment-hash-colon': length ($src4_len)"
 
 let src5 = $src4 | str replace 'to text' "str join \"\\n\""
-print $"   After replacing 'to text': length ($src5 | str length)"
+let src5_len = ($src5 | str length)
+print $"   After replacing 'to text': length ($src5_len)"
 print ""
 
 print "3. Final embed-in-script source:"
 print $src5
 print ""
-print $"   Hex: ($src5 | encode hex)"
+let src5_hex = ($src5 | encode hex)
+print $"   Hex: ($src5_hex)"
 print ""
 
 # Step 3: Build a test script like execute-and-parse-results does
@@ -77,19 +87,25 @@ print ""
 # Step 4: Execute and capture
 print "5. Executing subprocess..."
 let raw_output = (^$nu.current-exe -n -c $script_updated)
-print $"   Raw output length: ($raw_output | str length)"
-print $"   Raw output hex: ($raw_output | encode hex)"
+let raw_len = ($raw_output | str length)
+let raw_hex = ($raw_output | encode hex)
+print $"   Raw output length: ($raw_len)"
+print $"   Raw output hex: ($raw_hex)"
 print ""
 
 # Step 5: Try to parse
 print "6. Parsing output..."
 let regex = '(?s)' + $marker_open + '(.*?)' + $marker_close
-print $"   Regex pattern hex: ($regex | encode hex)"
+let regex_hex = ($regex | encode hex)
+print $"   Regex pattern hex: ($regex_hex)"
 
-let parsed = ($raw_output | ansi strip | parse -r $regex)
-print $"   Parsed results: ($parsed | length) captures"
+let stripped = ($raw_output | ansi strip)
+let parsed = ($stripped | parse -r $regex)
+let parsed_len = ($parsed | length)
+print $"   Parsed results: ($parsed_len) captures"
 if ($parsed | is-not-empty) {
-    print $"   First capture: ($parsed | get capture0 | first)"
+    let first_cap = ($parsed | get capture0 | first)
+    print $"   First capture: ($first_cap)"
 }
 print ""
 

--- a/misc/embed_debug.nu
+++ b/misc/embed_debug.nu
@@ -1,0 +1,96 @@
+# Debug script to trace exactly what execute-and-parse-results does
+# Run from dotnu root: nu misc/embed_debug.nu
+
+use ../dotnu/commands.nu *
+
+print "=== EMBED DEBUG ==="
+print ""
+
+# Step 1: Define the same closure as execute-and-parse-results
+let embed_in_script = {
+    let input = table -e
+    | comment-hash-colon
+
+    capture-marker
+    | append $input
+    | append (capture-marker --close)
+    | to text
+    | print
+}
+
+print "1. Original closure source:"
+let orig_src = (view source $embed_in_script)
+print $"   Length: ($orig_src | str length)"
+print $"   Hex (first 200): ($orig_src | encode hex | str substring 0..200)"
+print ""
+
+# Step 2: Apply the same replacements as execute-and-parse-results
+print "2. Applying str replace operations..."
+
+let src1 = $orig_src | 'def embed-in-script [] ' + $in
+print $"   After prepending 'def': length ($src1 | str length)"
+
+let marker_open = (capture-marker)
+let marker_close = (capture-marker --close)
+print $"   Marker open: ($marker_open | encode hex)"
+print $"   Marker close: ($marker_close | encode hex)"
+
+let src2 = $src1 | str replace 'capture-marker' $"'($marker_open)'"
+print $"   After replacing 'capture-marker': length ($src2 | str length)"
+let contains_marker = ($src2 | str contains ($marker_open))
+print $"   Contains marker in source: ($contains_marker)"
+
+let src3 = $src2 | str replace '(capture-marker --close)' $"'($marker_close)'"
+print $"   After replacing '(capture-marker --close)': length ($src3 | str length)"
+
+let src4 = $src3 | str replace 'comment-hash-colon' (comment-hash-colon --source-code)
+print $"   After replacing 'comment-hash-colon': length ($src4 | str length)"
+
+let src5 = $src4 | str replace 'to text' "str join \"\\n\""
+print $"   After replacing 'to text': length ($src5 | str length)"
+print ""
+
+print "3. Final embed-in-script source:"
+print $src5
+print ""
+print $"   Hex: ($src5 | encode hex)"
+print ""
+
+# Step 3: Build a test script like execute-and-parse-results does
+print "4. Building test script..."
+let test_script = "'hello world' | print $in"
+
+let script_updated = $test_script
+| lines
+| each {
+    if $in !~ '^\s*#' {
+        str replace -r '\| *print +\$in *' '| embed-in-script'
+    } else { }
+}
+| prepend $src5
+| str join "\n"
+
+print "   Script to execute:"
+print $script_updated
+print ""
+
+# Step 4: Execute and capture
+print "5. Executing subprocess..."
+let raw_output = (^$nu.current-exe -n -c $script_updated)
+print $"   Raw output length: ($raw_output | str length)"
+print $"   Raw output hex: ($raw_output | encode hex)"
+print ""
+
+# Step 5: Try to parse
+print "6. Parsing output..."
+let regex = '(?s)' + $marker_open + '(.*?)' + $marker_close
+print $"   Regex pattern hex: ($regex | encode hex)"
+
+let parsed = ($raw_output | ansi strip | parse -r $regex)
+print $"   Parsed results: ($parsed | length) captures"
+if ($parsed | is-not-empty) {
+    print $"   First capture: ($parsed | get capture0 | first)"
+}
+print ""
+
+print "=== END EMBED DEBUG ==="

--- a/misc/windows_debug.nu
+++ b/misc/windows_debug.nu
@@ -35,7 +35,7 @@ let real_open = (capture-marker)
 let real_close = (capture-marker --close)
 print $"   Open marker hex: ($real_open | encode hex)"
 print $"   Close marker hex: ($real_close | encode hex)"
-print $"   Expected: E2808BE2808C (ZWSP+ZWNJ) and E2808CE2808B (ZWNJ+ZWSP)"
+print $"   Expected: E2808BE2808C \('ZWSP+ZWNJ'\) and E2808CE2808B \('ZWNJ+ZWSP'\)"
 print ""
 
 print "5b. Zero-width chars through subprocess:"
@@ -52,7 +52,7 @@ print \($open + 'CAPTURED' + $close\)
 "
 let real_result = (nu -c $real_script | complete)
 print $"   Stdout hex: ($real_result.stdout | encode hex)"
-let real_parsed = ($real_result.stdout | parse -r $'(?s)($real_open)(.*?)($real_close)')
+let real_parsed = ($real_result.stdout | parse -r $"\(?s\)($real_open)\(.*?\)($real_close)")
 print $"   Parsed with real markers: ($real_parsed | length) captures"
 print ""
 

--- a/misc/windows_debug.nu
+++ b/misc/windows_debug.nu
@@ -33,8 +33,27 @@ print "5. Actual capture-marker values from dotnu:"
 use dotnu/commands.nu [capture-marker]
 let real_open = (capture-marker)
 let real_close = (capture-marker --close)
-print $"   Open marker: ($real_open)"
-print $"   Close marker: ($real_close)"
+print $"   Open marker hex: ($real_open | encode hex)"
+print $"   Close marker hex: ($real_close | encode hex)"
+print $"   Expected: E2808BE2808C (ZWSP+ZWNJ) and E2808CE2808B (ZWNJ+ZWSP)"
+print ""
+
+print "5b. Zero-width chars through subprocess:"
+let sub_marker = (nu -c "print '\\u{200B}\\u{200C}'")
+print $"   Subprocess marker hex: ($sub_marker | encode hex)"
+print ""
+
+print "5c. Real capture-marker through subprocess:"
+let real_script = $"
+use dotnu/commands.nu [capture-marker]
+let open = \(capture-marker\)
+let close = \(capture-marker --close\)
+print \($open + 'CAPTURED' + $close\)
+"
+let real_result = (nu -c $real_script | complete)
+print $"   Stdout hex: ($real_result.stdout | encode hex)"
+let real_parsed = ($real_result.stdout | parse -r $'(?s)($real_open)(.*?)($real_close)')
+print $"   Parsed with real markers: ($real_parsed | length) captures"
 print ""
 
 print "6. Simulated embed capture (like execute-and-parse-results):"

--- a/misc/windows_debug.nu
+++ b/misc/windows_debug.nu
@@ -25,12 +25,12 @@ let marker_open = "<<<DOTNU-EMBED-CAPTURE>>>"
 let marker_close = "<<<DOTNU-EMBED-CAPTURE>>><<<END>>>"
 let test_str = $"before\n($marker_open)\ncaptured content\n($marker_close)\nafter"
 print $"   Test string created"
-let parsed = ($test_str | parse -r $'(?s)<<<DOTNU-EMBED-CAPTURE>>>\(.*?\)<<<DOTNU-EMBED-CAPTURE>>><<<END>>>')
+let parsed = ($test_str | parse -r '(?s)<<<DOTNU-EMBED-CAPTURE>>>\(.*?\)<<<DOTNU-EMBED-CAPTURE>>><<<END>>>')
 print $"   Parsed result: ($parsed)"
 print ""
 
 print "5. Actual capture-marker values from dotnu:"
-use dotnu/commands.nu [capture-marker]
+use ../dotnu/commands.nu *
 let real_open = (capture-marker)
 let real_close = (capture-marker --close)
 print $"   Open marker hex: ($real_open | encode hex)"
@@ -72,7 +72,7 @@ print "   Running subprocess with embed script..."
 let result = (nu -c $script | complete)
 print $"   Exit code: ($result.exit_code)"
 print $"   Stdout length: ($result.stdout | str length)"
-print $"   Stdout hex (first 100): ($result.stdout | encode hex | str substring 0..100)"
+print $"   Stdout hex : ($result.stdout | encode hex | str substring 0..100)"
 print ""
 
 print "7. Parse the subprocess output:"

--- a/misc/windows_debug.nu
+++ b/misc/windows_debug.nu
@@ -1,0 +1,72 @@
+# Windows debugging script for dotnu CRLF issues
+# Run with: nu misc/windows_debug.nu
+
+print "=== DOTNU WINDOWS DEBUG ==="
+print ""
+
+print "1. System info:"
+print $"   OS: (sys host | get name)"
+print $"   Nu version: (version | get version)"
+print ""
+
+print "2. Line ending test (expect 0A on Unix, 0D0A on Windows):"
+let line_hex = (nu -c "'line1\nline2' | to text" | encode hex | str substring 0..30)
+print $"   to text hex: ($line_hex)"
+print ""
+
+print "3. Subprocess output test:"
+let sub_out = (nu -c "'hello from subprocess'")
+print $"   Output: ($sub_out)"
+print $"   Hex: ($sub_out | encode hex)"
+print ""
+
+print "4. Capture marker test:"
+let marker_open = "<<<DOTNU-EMBED-CAPTURE>>>"
+let marker_close = "<<<DOTNU-EMBED-CAPTURE>>><<<END>>>"
+let test_str = $"before\n($marker_open)\ncaptured content\n($marker_close)\nafter"
+print $"   Test string created"
+let parsed = ($test_str | parse -r $'(?s)<<<DOTNU-EMBED-CAPTURE>>>\(.*?\)<<<DOTNU-EMBED-CAPTURE>>><<<END>>>')
+print $"   Parsed result: ($parsed)"
+print ""
+
+print "5. Actual capture-marker values from dotnu:"
+use dotnu/commands.nu [capture-marker]
+let real_open = (capture-marker)
+let real_close = (capture-marker --close)
+print $"   Open marker: ($real_open)"
+print $"   Close marker: ($real_close)"
+print ""
+
+print "6. Simulated embed capture (like execute-and-parse-results):"
+let script = "
+def embed-in-script [] {
+    let input = $in | table -e
+    '<<<DOTNU>>>'
+    | append $input
+    | append '<<<DOTNU>>><<<END>>>'
+    | str join \"\\n\"
+    | print
+}
+'test data' | embed-in-script
+"
+print "   Running subprocess with embed script..."
+let result = (nu -c $script | complete)
+print $"   Exit code: ($result.exit_code)"
+print $"   Stdout length: ($result.stdout | str length)"
+print $"   Stdout hex (first 100): ($result.stdout | encode hex | str substring 0..100)"
+print ""
+
+print "7. Parse the subprocess output:"
+let parsed2 = ($result.stdout | parse -r '(?s)<<<DOTNU>>>(.*?)<<<DOTNU>>><<<END>>>')
+print $"   Parsed captures: ($parsed2 | length)"
+if ($parsed2 | is-not-empty) {
+    print $"   First capture: ($parsed2 | get 0)"
+}
+print ""
+
+print "8. Test str join with explicit newline:"
+let joined = (["a" "b" "c"] | str join "\n")
+print $"   Joined hex: ($joined | encode hex)"
+print ""
+
+print "=== END DEBUG ==="

--- a/tests/assets/attribute-edge-cases.nu
+++ b/tests/assets/attribute-edge-cases.nu
@@ -14,6 +14,14 @@ export def 'email-formatter' [] {
     $template | str replace '@support' 'support@example.com'
 }
 
+# Raw string with @fake at line start - should NOT be treated as attribute
+export def 'raw-string-command' [] {
+    r###'
+@fake is a fabricated raw string
+'###
+    email-formatter  # this call SHOULD appear
+}
+
 # Regular command for dependency testing
 export def 'main-command' [] {
     email-formatter

--- a/tests/assets/attribute-edge-cases.nu
+++ b/tests/assets/attribute-edge-cases.nu
@@ -1,0 +1,20 @@
+# Test file for attribute decorator edge cases
+
+# Multi-word attribute with closure - calls inside should be excluded
+@example 'demo' {
+    email-formatter  # this call should NOT appear in dependencies
+}
+export def 'decorated-command' [] {
+    email-formatter  # this call SHOULD appear
+}
+
+# This command has @something in a string - should NOT be treated as attribute
+export def 'email-formatter' [] {
+    let template = "Contact us @support or @help for assistance"
+    $template | str replace '@support' 'support@example.com'
+}
+
+# Regular command for dependency testing
+export def 'main-command' [] {
+    email-formatter
+}

--- a/tests/assets/attribute-edge-cases.nu
+++ b/tests/assets/attribute-edge-cases.nu
@@ -26,3 +26,12 @@ export def 'raw-string-command' [] {
 export def 'main-command' [] {
     email-formatter
 }
+
+# Raw string with @example 'text' that MATCHES attribute regex - should NOT be treated as attribute
+# This is the tricky case: the line looks exactly like a real attribute decorator
+export def 'tricky-raw-string-command' [] {
+    r###'
+@example 'this line matches attribute regex but is inside raw string!'
+'###
+    email-formatter  # this call SHOULD appear - bug if it doesn't!
+}

--- a/tests/assets/dotnu-capture-updated.nu
+++ b/tests/assets/dotnu-capture-updated.nu
@@ -16,7 +16,7 @@ ls | sort-by modified -r | last 2 | print $in
 
 random int | print $in
 
-# => 5037388629847034664
+# => 5315410494483668762
 
 'Say hello to the core team of the Nushell'
 | str replace 'Nushell' 'Best shell'

--- a/tests/assets/dotnu-capture-updated.nu
+++ b/tests/assets/dotnu-capture-updated.nu
@@ -16,7 +16,7 @@ ls | sort-by modified -r | last 2 | print $in
 
 random int | print $in
 
-# => 5315410494483668762
+# => 6338540342646442170
 
 'Say hello to the core team of the Nushell'
 | str replace 'Nushell' 'Best shell'

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -335,8 +335,8 @@ def "set-x transforms script with echo flag" [] {
 def "extract-command-code extracts command with echo flag" [] {
     let result = extract-command-code tests/assets/b/example-mod1.nu lscustom --echo
 
-    # Should include source statement for module
-    assert ($result =~ 'source tests/assets/b/example-mod1.nu')
+    # Should include source statement for module (path separators vary by OS)
+    assert ($result =~ 'source.*example-mod1\.nu')
     # Should include the command code
     assert ($result =~ 'ls')
 }
@@ -345,7 +345,8 @@ def "extract-command-code extracts command with echo flag" [] {
 def "extract-command-code handles quoted command names" [] {
     let result = extract-command-code tests/assets/b/example-mod1.nu 'command-5' --echo
 
-    assert ($result =~ 'source tests/assets/b/example-mod1.nu')
+    # Path separators vary by OS
+    assert ($result =~ 'source.*example-mod1\.nu')
     assert ($result =~ 'command-3')
 }
 

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -416,14 +416,16 @@ def "embeds-update preserves script structure" [] {
 @test
 def "embeds-setup sets capture path in env" [] {
     # Test without --auto-commit to avoid git operations
-    embeds-setup /tmp/test-capture.nu
+    let test_path = ($nu.temp-path | path join 'test-capture.nu')
+    embeds-setup $test_path
 
-    assert equal $env.dotnu.embeds-capture-path '/tmp/test-capture.nu'
+    assert equal $env.dotnu.embeds-capture-path $test_path
 }
 
 @test
 def "embeds-setup adds .nu extension if missing" [] {
-    embeds-setup /tmp/test-capture
+    let test_path = ($nu.temp-path | path join 'test-capture')
+    embeds-setup $test_path
 
     assert ($env.dotnu.embeds-capture-path | str ends-with '.nu')
 }

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -1,12 +1,8 @@
-print -e "DEBUG: test_commands.nu starting"
 use std assert
-print -e "DEBUG: std assert imported"
 use std/testing *
-print -e "DEBUG: std/testing imported"
 
 # Import all functions from commands.nu (including internals not re-exported via mod.nu)
 use ../dotnu/commands.nu *
-print -e "DEBUG: commands.nu imported"
 
 # =============================================================================
 # Tests for escape-for-quotes

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -1,8 +1,12 @@
+print -e "DEBUG: test_commands.nu starting"
 use std assert
+print -e "DEBUG: std assert imported"
 use std/testing *
+print -e "DEBUG: std/testing imported"
 
 # Import all functions from commands.nu (including internals not re-exported via mod.nu)
 use ../dotnu/commands.nu *
+print -e "DEBUG: commands.nu imported"
 
 # =============================================================================
 # Tests for escape-for-quotes

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -257,6 +257,21 @@ def "dependencies ignores @fake inside raw strings" [] {
     assert ('email-formatter' in $raw_calls.callee) "raw-string-command should call email-formatter"
 }
 
+@test
+def "dependencies ignores @example inside raw strings even when matching attribute regex" [] {
+    # This tests the tricky case: @example 'text' inside raw string looks exactly like
+    # a real attribute decorator and matches the regex, but should NOT be treated as one
+    let result = list-module-commands tests/assets/attribute-edge-cases.nu
+
+    # The fake @example inside raw string should NOT appear as a caller
+    let example_callers = $result | where caller == '@example'
+    assert (($example_callers | length) == 0) "@example inside raw string should not be a caller"
+
+    # tricky-raw-string-command should call email-formatter (call after the raw string)
+    let tricky_calls = $result | where caller == 'tricky-raw-string-command'
+    assert ('email-formatter' in $tricky_calls.callee) "tricky-raw-string-command should call email-formatter"
+}
+
 # =============================================================================
 # Tests for filter-commands-with-no-tests
 # =============================================================================

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -245,6 +245,18 @@ def "dependencies ignores @something inside strings" [] {
     assert ('email-formatter' in $main_calls.callee) "main-command should call email-formatter"
 }
 
+@test
+def "dependencies ignores @fake inside raw strings" [] {
+    let result = list-module-commands tests/assets/attribute-edge-cases.nu
+
+    # @fake should NOT appear as a caller
+    assert ('@fake' not-in $result.caller) "@fake inside raw string should not be a caller"
+
+    # raw-string-command should call email-formatter (call after raw string)
+    let raw_calls = $result | where caller == 'raw-string-command'
+    assert ('email-formatter' in $raw_calls.callee) "raw-string-command should call email-formatter"
+}
+
 # =============================================================================
 # Tests for filter-commands-with-no-tests
 # =============================================================================

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -24,9 +24,12 @@ export def 'main test-unit' [
     --json # output results as JSON for external consumption
     --quiet # suppress terminal output (for use when called from main test)
 ] {
+    print -e "DEBUG: importing nutest"
     use ../nutest/nutest
+    print -e "DEBUG: nutest imported"
 
     let display = if ($json or $quiet) { 'nothing' } else { 'terminal' }
+    print -e $"DEBUG: calling nutest run-tests with display=($display)"
     # Match only test_commands to exclude test assets in subdirectories
     nutest run-tests --path tests/ --match-suites 'test_commands' --returns summary --display $display
     | if $json { to json --raw } else { }

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -7,8 +7,13 @@ export def main [] { }
 export def 'main test' [
     --json # output results as JSON for external consumption
 ] {
+    print -e "DEBUG: starting tests"
+    print -e "DEBUG: starting unit tests"
     let unit = main test-unit --quiet=$json
+    print -e "DEBUG: unit tests done"
+    print -e "DEBUG: starting integration tests"
     let integration = main test-integration
+    print -e "DEBUG: integration tests done"
 
     {unit: $unit integration: $integration}
     | if $json { to json --raw } else { }
@@ -31,12 +36,16 @@ export def 'main test-unit' [
 export def 'main test-integration' [
     --json # output results as JSON for external consumption
 ] {
-    [
-        (test-dependencies)
-        (test-dependencies-keep_builtins)
-        (test-embeds-remove)
-        (test-embeds-update)
-    ]
+    print -e "DEBUG: test-dependencies"
+    let t1 = test-dependencies
+    print -e "DEBUG: test-dependencies-keep_builtins"
+    let t2 = test-dependencies-keep_builtins
+    print -e "DEBUG: test-embeds-remove"
+    let t3 = test-embeds-remove
+    print -e "DEBUG: test-embeds-update"
+    let t4 = test-embeds-update
+    print -e "DEBUG: all integration tests done"
+    [$t1 $t2 $t3 $t4]
     # Run numd on README if available
     | if (scope modules | where name == 'numd' | is-not-empty) {
         append (test-numd-readme)

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -7,13 +7,8 @@ export def main [] { }
 export def 'main test' [
     --json # output results as JSON for external consumption
 ] {
-    print -e "DEBUG: starting tests"
-    print -e "DEBUG: starting unit tests"
     let unit = main test-unit --quiet=$json
-    print -e "DEBUG: unit tests done"
-    print -e "DEBUG: starting integration tests"
     let integration = main test-integration
-    print -e "DEBUG: integration tests done"
 
     {unit: $unit integration: $integration}
     | if $json { to json --raw } else { }
@@ -24,12 +19,9 @@ export def 'main test-unit' [
     --json # output results as JSON for external consumption
     --quiet # suppress terminal output (for use when called from main test)
 ] {
-    print -e "DEBUG: importing nutest"
     use ../nutest/nutest
-    print -e "DEBUG: nutest imported"
 
     let display = if ($json or $quiet) { 'nothing' } else { 'terminal' }
-    print -e $"DEBUG: calling nutest run-tests with display=($display)"
     # Match only test_commands to exclude test assets in subdirectories
     nutest run-tests --path tests/ --match-suites 'test_commands' --returns summary --display $display
     | if $json { to json --raw } else { }
@@ -39,16 +31,12 @@ export def 'main test-unit' [
 export def 'main test-integration' [
     --json # output results as JSON for external consumption
 ] {
-    print -e "DEBUG: test-dependencies"
-    let t1 = test-dependencies
-    print -e "DEBUG: test-dependencies-keep_builtins"
-    let t2 = test-dependencies-keep_builtins
-    print -e "DEBUG: test-embeds-remove"
-    let t3 = test-embeds-remove
-    print -e "DEBUG: test-embeds-update"
-    let t4 = test-embeds-update
-    print -e "DEBUG: all integration tests done"
-    [$t1 $t2 $t3 $t4]
+    [
+        (test-dependencies)
+        (test-dependencies-keep_builtins)
+        (test-embeds-remove)
+        (test-embeds-update)
+    ]
     # Run numd on README if available
     | if (scope modules | where name == 'numd' | is-not-empty) {
         append (test-numd-readme)


### PR DESCRIPTION
## Summary

- Use AST parsing to detect `@attribute` decorators accurately instead of line-based regex
- Cache AST tokens to avoid parsing the file twice (perf improvement)
- Exclude calls inside attribute blocks (e.g., `@example { some-call }`) from dependencies
- Add comprehensive tests for edge cases: `@something` inside strings, raw strings, and attribute closures

## Changes

- **dotnu/commands.nu**: Refactored `list-module-commands` with two-phase parsing:
  1. Line-based parsing for `def` statements (need byte offsets)
  2. AST-based parsing for attributes (prevents false positives)
- **tests/assets/attribute-edge-cases.nu**: New test fixture covering tricky cases
- **tests/test_commands.nu**: 4 new tests for attribute edge cases
- **README.md**: Clarified `filter-commands-with-no-tests` detection logic
- **CLAUDE.md**: Added Claude Code guidance document

## Test plan

- [x] All unit tests pass (`nu toolkit.nu test-unit`)
- [x] Edge cases verified: `@example` in raw strings no longer creates false callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)