### PR TITLE
feat: use AST to detect attributes, preventing false positives in strings

### DIFF
--- a/tests/assets/attribute-edge-cases.nu
+++ b/tests/assets/attribute-edge-cases.nu
@@ -1,0 +1,20 @@
+# Test file for attribute decorator edge cases
+
+# Multi-word attribute with closure - calls inside should be excluded
+@example 'demo' {
+    email-formatter  # this call should NOT appear in dependencies
+}
+export def 'decorated-command' [] {
+    email-formatter  # this call SHOULD appear
+}
+
+# This command has @something in a string - should NOT be treated as attribute
+export def 'email-formatter' [] {
+    let template = "Contact us @support or @help for assistance"
+    $template | str replace '@support' 'support@example.com'
+}
+
+# Regular command for dependency testing
+export def 'main-command' [] {
+    email-formatter
+}


### PR DESCRIPTION
## Summary
- Use AST parsing instead of regex to detect `@test`, `@example` and other attribute decorators
- Prevents false positives when `@something` appears inside strings
- Cache AST tokens to avoid parsing file twice (performance optimization)

## Test plan
- [x] Added tests for attribute edge cases (strings containing @patterns)
- [x] All 44 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)