### PR TITLE
fix: add shell: bash to CI steps for Windows compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,14 @@ jobs:
           version: "*"
 
       - name: Install nutest
+        shell: bash
         run: git clone https://github.com/vyadh/nutest.git ../nutest
 
       - name: Run tests
+        shell: bash
         run: nu toolkit.nu test --json
 
       - name: Show diff of changed files
         if: always()
+        shell: bash
         run: git diff


### PR DESCRIPTION
## Summary
- Add `shell: bash` to all CI run steps
- Prevents Windows runners from using PowerShell, which can hang on git operations due to credential manager prompts

## Test plan
- [x] CI should no longer hang on Windows runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)