### PR TITLE
fix: Windows CRLF compatibility for core functions

### DIFF
--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -715,7 +715,7 @@ export def execute-and-parse-results [
         capture-marker
         | append $input
         | append (capture-marker --close)
-        | to text
+        | str join "\n"
         | print
     }
 
@@ -724,7 +724,6 @@ export def execute-and-parse-results [
     | str replace 'capture-marker' $"'(capture-marker)'"
     | str replace '(capture-marker --close)' $"'(capture-marker --close)'"
     | str replace 'comment-hash-colon' (comment-hash-colon --source-code)
-    | str replace 'to text' "str join \"\\n\"" # Windows CRLF fix
 
     let script_updated = $script
     | lines


### PR DESCRIPTION
## Summary
Windows compatibility fixes following numd's pattern:

**CRLF→LF normalization at input:**
- `set-x`
- `embeds-update`
- `embeds-remove`
- `variable-definitions-to-record`

**Explicit LF output (`str join "\n"` instead of `to text`):**
- `set-x`
- `extract-command-code`
- `embeds-remove`
- `execute-and-parse-results`

**Bug fix:**
- `capture-marker`: Changed from `def` to `export def` (was not exported, causing silent import failures on Windows)

**Error handling:**
- `variable-definitions-to-record`: Handle empty parse results and subprocess errors gracefully

## Test plan
- [x] All tests pass locally on macOS
- [ ] Test on Windows VM to verify embeds-update works

🤖 Generated with [Claude Code](https://claude.com/claude-code)