### PR TITLE
fix: Windows-compatible test assertions

### DIFF
--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -278,8 +278,8 @@ def "set-x transforms script with echo flag" [] {
 def "extract-command-code extracts command with echo flag" [] {
     let result = extract-command-code tests/assets/b/example-mod1.nu lscustom --echo
 
-    # Should include source statement for module
-    assert ($result =~ 'source tests/assets/b/example-mod1.nu')
+    # Should include source statement for module (path separators vary by OS)
+    assert ($result =~ 'source.*example-mod1\.nu')
     # Should include the command code
     assert ($result =~ 'ls')
 }
@@ -288,7 +288,8 @@ def "extract-command-code extracts command with echo flag" [] {
 def "extract-command-code handles quoted command names" [] {
     let result = extract-command-code tests/assets/b/example-mod1.nu 'command-5' --echo
 
-    assert ($result =~ 'source tests/assets/b/example-mod1.nu')
+    # Path separators vary by OS
+    assert ($result =~ 'source.*example-mod1\.nu')
     assert ($result =~ 'command-3')
 }
 
@@ -359,14 +360,16 @@ def "embeds-update preserves script structure" [] {
 @test
 def "embeds-setup sets capture path in env" [] {
     # Test without --auto-commit to avoid git operations
-    embeds-setup /tmp/test-capture.nu
+    let test_path = ($nu.temp-path | path join 'test-capture.nu')
+    embeds-setup $test_path
 
-    assert equal $env.dotnu.embeds-capture-path '/tmp/test-capture.nu'
+    assert equal $env.dotnu.embeds-capture-path $test_path
 }
 
 @test
 def "embeds-setup adds .nu extension if missing" [] {
-    embeds-setup /tmp/test-capture
+    let test_path = ($nu.temp-path | path join 'test-capture')
+    embeds-setup $test_path
 
     assert ($env.dotnu.embeds-capture-path | str ends-with '.nu')
 }


### PR DESCRIPTION
## Summary
Platform-independent test fixes:

- **Temp paths**: Use `$nu.temp-path` instead of hardcoded `/tmp/` for `embeds-setup` tests
- **Path patterns**: Use regex `source.*example-mod1\.nu` to match both Unix (`/`) and Windows (`\`) path separators in `extract-command-code` tests

## Dependencies
- Requires #31 (fix/windows-crlf) to be merged first

## Test plan
- [x] All tests pass locally
- [ ] All 46 tests should pass on Windows CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)