### PR TITLE
fix: remove empty line between code blocks and embeds

### DIFF
--- a/dotnu-capture.nu
+++ b/dotnu-capture.nu
@@ -11,18 +11,15 @@
 # I wanted this feature many times throughout my nushell history; however, once I implemented it, I forgot about my initial needs and haven't used it in production so far.
 
 ls | sort-by modified -r | last 2 | print $in
-
 # => ╭─#─┬──────name──────┬─type─┬─size──┬───modified───╮
 # => │ 0 │ zzz_md_backups │ dir  │ 160 B │ 2 months ago │
 # => │ 1 │ test.nu        │ file │  45 B │ 3 months ago │
 # => ╰─#─┴──────name──────┴─type─┴─size──┴───modified───╯
 
 random int | print $in
-
 # => 6970240173764648305
 
 'Say hello to the core team of the Nushell'
 | str replace 'Nushell' 'Best shell'
 | print $in
-
 # => Say hello to the core team of the Best shell

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -720,17 +720,14 @@ export def execute-and-parse-results [
         let input = table -e
         | comment-hash-colon
 
-        capture-marker
-        | append $input
-        | append (capture-marker --close)
-        | str join "\n"
+        (capture-marker) + $input + "\n" + (capture-marker --close)
         | print
     }
 
     let embed_in_script_src = view source $embed_in_script
     | 'def embed-in-script [] ' + $in
-    | str replace 'capture-marker' $"'(capture-marker)'"
     | str replace '(capture-marker --close)' $"'(capture-marker --close)'"
+    | str replace 'capture-marker' $"'(capture-marker)'"
     | str replace 'comment-hash-colon' (comment-hash-colon --source-code)
 
     let script_updated = $script
@@ -764,7 +761,6 @@ export def find-capture-points [] {
 # Removes annotation lines starting with "# => " from the script
 export def embeds-remove [] {
     if $nu.os-info.family == windows { str replace --all (char crlf) "\n" } else { }
-    | str replace -a "\n\n# => " "\n# => "
     | lines
     | where not ($it starts-with "# => ")
     | str join "\n"

--- a/tests/assets/dotnu-capture-updated.nu
+++ b/tests/assets/dotnu-capture-updated.nu
@@ -6,7 +6,6 @@
 # https://github.com/nushell-prophet/dotnu
 
 ls | sort-by modified -r | last 2 | print $in
-
 # => ╭───┬──────────────────────────────┬──────┬───────┬────────────╮
 # => │ # │             name             │ type │ size  │  modified  │
 # => ├───┼──────────────────────────────┼──────┼───────┼────────────┤
@@ -15,11 +14,9 @@ ls | sort-by modified -r | last 2 | print $in
 # => ╰───┴──────────────────────────────┴──────┴───────┴────────────╯
 
 random int | print $in
-
 # => 5037388629847034664
 
 'Say hello to the core team of the Nushell'
 | str replace 'Nushell' 'Best shell'
 | print $in
-
 # => Say hello to the core team of the Best shell

--- a/tests/assets/dotnu-capture.nu
+++ b/tests/assets/dotnu-capture.nu
@@ -6,18 +6,15 @@
 # https://github.com/nushell-prophet/dotnu
 
 ls | sort-by modified -r | last 2 | print $in
-
 # => ╭─#─┬──────name──────┬─type─┬─size──┬───modified───╮
 # => │ 0 │ zzz_md_backups │ dir  │ 160 B │ 2 months ago │
 # => │ 1 │ test.nu        │ file │  45 B │ 3 months ago │
 # => ╰─#─┴──────name──────┴─type─┴─size──┴───modified───╯
 
 random int | print $in
-
 # => 6970240173764648305
 
 'Say hello to the core team of the Nushell'
 | str replace 'Nushell' 'Best shell'
 | print $in
-
 # => Say hello to the core team of the Best shell


### PR DESCRIPTION
## Summary
- Remove the empty line that was being inserted between code blocks and `# =>` embed annotations
- Embeds now appear directly after the `| print $in` line without a blank separator

## Changes
- **Core fix**: Changed embed generation from `append | str join "\n"` pattern to direct string concatenation in `execute-and-parse-results`
- **Cleanup**: Removed redundant empty line collapse in `embeds-remove` (no longer needed)
- **Test assets**: Updated all example files to use the new format

## Test plan
- [x] All 44 unit tests pass
- [x] Integration tests pass
- [x] `embeds-update` produces output without empty lines before embeds
- [x] `embeds-remove` correctly strips embed annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)