### PR TITLE
Rework list-exported-commands and fix embed/statement parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@ dotnu/
 - `dependencies` - Analyze command call chains
 - `extract-command-code` - Extract command with its dependencies
 - `filter-commands-with-no-tests` - Find untested commands
-- `list-exported-commands` - List module's exported commands
+- `list-module-exports` - List all exported definitions (export def + export use)
+- `list-module-interface` - List module's callable interface (main commands)
 - `embeds-*` / `embed-add` - Literate programming tools
 - `set-x` / `generate-numd` - Script profiling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,11 @@ nu toolkit.nu release --major   # major bump
 
 **Important**: Always use `nu toolkit.nu test` (not `test-unit` or `test-integration` separately). The combined command provides proper test output and summary.
 
+```bash
+# Check test coverage - requires both source AND test files
+nu -c 'use dotnu/; ["dotnu/*.nu" "tests/test_commands.nu" "toolkit.nu"] | each { glob $in } | flatten | dotnu dependencies ...$in | dotnu filter-commands-with-no-tests'
+```
+
 ## Architecture
 
 ### Module Structure
@@ -37,6 +42,10 @@ dotnu/
 ```
 
 **Export convention**: All commands in `commands.nu` are exported by default (for internal use, testing, and development). The public API is managed through `mod.nu`, which selectively re-exports only the user-facing commands. To add a command to the public API, add it to the list in `mod.nu`.
+
+**Imports**:
+- `use dotnu/` - import public API commands
+- `use dotnu/commands.nu *` - import all commands (including internal)
 
 **mod.nu** exports these public commands:
 - `dependencies` - Analyze command call chains

--- a/README.md
+++ b/README.md
@@ -203,13 +203,13 @@ dotnu dependencies --help
 # =>   ╰───┴───────┴────────╯
 # =>
 # => Examples:
-# =>
+# =>   Analyze command dependencies in a module
 # =>   > dotnu dependencies ...(glob tests/assets/module-say/say/*.nu)
 # =>   ╭───┬──────────┬────────────────────┬──────────┬──────╮
 # =>   │ # │  caller  │ filename_of_caller │  callee  │ step │
 # =>   ├───┼──────────┼────────────────────┼──────────┼──────┤
-# =>   │ 0 │ hello    │ hello.nu           │          │    0 │
-# =>   │ 1 │ question │ ask.nu             │          │    0 │
+# =>   │ 0 │ question │ ask.nu             │          │    0 │
+# =>   │ 1 │ hello    │ hello.nu           │          │    0 │
 # =>   │ 2 │ say      │ mod.nu             │ hello    │    0 │
 # =>   │ 3 │ say      │ mod.nu             │ hi       │    0 │
 # =>   │ 4 │ say      │ mod.nu             │ question │    0 │
@@ -240,13 +240,13 @@ dotnu filter-commands-with-no-tests --help
 # =>   ╰───┴───────┴────────╯
 # =>
 # => Examples:
-# =>
+# =>   Find commands not covered by tests
 # =>   > dependencies ...(glob tests/assets/module-say/say/*.nu) | filter-commands-with-no-tests
 # =>   ╭───┬──────────┬────────────────────╮
 # =>   │ # │  caller  │ filename_of_caller │
 # =>   ├───┼──────────┼────────────────────┤
-# =>   │ 0 │ hello    │ hello.nu           │
-# =>   │ 1 │ question │ ask.nu             │
+# =>   │ 0 │ question │ ask.nu             │
+# =>   │ 1 │ hello    │ hello.nu           │
 # =>   │ 2 │ say      │ mod.nu             │
 # =>   ╰───┴──────────┴────────────────────╯
 # =>
@@ -283,7 +283,7 @@ dotnu set-x --help
 # =>   ╰───┴───────┴────────╯
 # =>
 # => Examples:
-# =>
+# =>   Generate script with timing instrumentation
 # =>   > set-x tests/assets/set-x-demo.nu --echo | lines | first 3 | to text
 # =>   mut $prev_ts = ( date now )
 # =>   print ("> sleep 0.5sec" | nu-highlight)
@@ -403,13 +403,13 @@ List all exported definitions from a module file. Finds commands from `export de
 
 ```nushell
 dotnu list-module-exports dotnu/mod.nu | first 5
-# => ╭───┬─────────────────────╮
-# => │ 0 │ dependencies        │
-# => │ 1 │ embed-add           │
-# => │ 2 │ embeds-capture-start│
-# => │ 3 │ embeds-capture-stop │
-# => │ 4 │ embeds-remove       │
-# => ╰───┴─────────────────────╯
+# => ╭───┬──────────────────────╮
+# => │ 0 │ dependencies         │
+# => │ 1 │ embed-add            │
+# => │ 2 │ embeds-capture-start │
+# => │ 3 │ embeds-capture-stop  │
+# => │ 4 │ embeds-remove        │
+# => ╰───┴──────────────────────╯
 ```
 
 ### `dotnu list-module-interface`

--- a/README.md
+++ b/README.md
@@ -397,29 +397,30 @@ dotnu extract-command-code --help
 # =>
 ```
 
-### `dotnu list-exported-commands`
+### `dotnu list-module-exports`
 
-List commands defined in a module file. Use `--export` to show only exported commands.
+List all exported definitions from a module file. Finds commands from `export def` and `export use [...commands]` patterns.
 
 ```nushell
-dotnu list-exported-commands --help
-# => Usage:
-# =>   > list-exported-commands {flags} <$path>
-# =>
-# => Flags:
-# =>   -h, --help: Display the help message for this command
-# =>   --export: use only commands that are exported
-# =>
-# => Parameters:
-# =>   $path <path>
-# =>
-# => Input/output types:
-# =>   ╭───┬───────┬────────╮
-# =>   │ # │ input │ output │
-# =>   ├───┼───────┼────────┤
-# =>   │ 0 │ any   │ any    │
-# =>   ╰───┴───────┴────────╯
-# =>
+dotnu list-module-exports dotnu/mod.nu | first 5
+# => ╭───┬─────────────────────╮
+# => │ 0 │ dependencies        │
+# => │ 1 │ embed-add           │
+# => │ 2 │ embeds-capture-start│
+# => │ 3 │ embeds-capture-stop │
+# => │ 4 │ embeds-remove       │
+# => ╰───┴─────────────────────╯
+```
+
+### `dotnu list-module-interface`
+
+List module's callable interface - the `main` and `main subcommand` patterns that become available when you `use` the module.
+
+```nushell
+dotnu list-module-interface tests/assets/b/example-mod1.nu
+# => ╭───┬──────╮
+# => │ 0 │ main │
+# => ╰───┴──────╯
 ```
 
 ### `dotnu module-commands-code-to-record`

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -269,8 +269,10 @@ export def 'examples-update' [
     # Using full original text ensures unique matches even with duplicate results
     let updated = $results | reduce --fold $content {|item acc|
         # Build new example by replacing just the result value in the original
+        # Escape $ as $$ to prevent regex backreference interpretation
+        let escaped_result = $item.new_result | str replace -a '$' '$$'
         let new_example = $item.original
-        | str replace -r '\} --result .+$' $"} --result ($item.new_result)"
+        | str replace -r '\} --result .+$' $"} --result ($escaped_result)"
 
         $acc | str replace $item.original $new_example
     }

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -171,19 +171,9 @@ export def 'list-exported-commands' [
     let source = open $path -r
 
     if $export {
-        # Try export def pattern first
-        let from_def = $source
-        | lines
-        | where $it =~ '^export def '
-        | extract-command-name
+        $source
+        | extract-exported-commands
         | replace-main-with-module-name $path
-
-        # Try export use [...] pattern via AST if no export def found
-        let from_use = if ($from_def | is-empty) {
-            $source | extract-export-use-commands
-        } else { [] }
-
-        $from_def | append $from_use
     } else {
         $source
         | lines
@@ -976,31 +966,33 @@ export def capture-marker [
     }
 }
 
-# Extract command names from `export use module.nu [commands]` pattern using AST
+# Extract exported command names using AST
 #
-# When a module uses selective re-export like:
-#   export use commands.nu ["cmd1" "cmd2"]
-# This extracts the command names from the list.
-export def extract-export-use-commands []: string -> list<string> {
+# Handles both patterns:
+# - `export def cmd-name []` → extracts cmd-name
+# - `export use module.nu ["cmd1" "cmd2"]` → extracts cmd1, cmd2
+export def extract-exported-commands []: string -> list<string> {
     let tokens = ast --flatten $in | flatten span
 
-    # Find export use internal call
-    let export_use_matches = $tokens
-    | enumerate
-    | where { $in.item.content == 'export use' and $in.item.shape == 'shape_internalcall' }
-
-    if ($export_use_matches | is-empty) { return [] }
-
-    let export_use_idx = $export_use_matches | first | get index
-
-    # Get tokens after export use: module path, then list with command names
-    # Pattern: [export use] [module.nu] [ [cmd1] [cmd2] ... ]
-    # shape_string tokens inside shape_list are the command names
     $tokens
-    | skip ($export_use_idx + 2)  # Skip "export use" and module path
-    | where shape == 'shape_string'
-    | get content
-    | each { str trim -c '"' }
+    | enumerate
+    | where { $in.item.content in ['export def' 'export use'] }
+    | each {|match|
+        let idx = $match.index
+        if $match.item.content == 'export def' {
+            # Command name is next token
+            $tokens | get ($idx + 1) | get content | str trim -c "'" | str trim -c '"'
+        } else {
+            # export use: skip module path, get shape_string tokens from list
+            $tokens
+            | skip ($idx + 2)
+            | take while { $in.shape in ['shape_string' 'shape_list'] }
+            | where shape == 'shape_string'
+            | get content
+            | str trim -c '"'
+        }
+    }
+    | flatten
 }
 
 # Complete AST output by filling gaps with synthetic tokens

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -168,14 +168,26 @@ export def 'list-exported-commands' [
     $path: path
     --export # use only commands that are exported
 ] {
-    open $path -r
-    | lines
-    | if $export {
-        where $it =~ '^export def '
+    let source = open $path -r
+
+    if $export {
+        # Try export def pattern first
+        let from_def = $source
+        | lines
+        | where $it =~ '^export def '
         | extract-command-name
         | replace-main-with-module-name $path
+
+        # Try export use [...] pattern via AST if no export def found
+        let from_use = if ($from_def | is-empty) {
+            $source | extract-export-use-commands
+        } else { [] }
+
+        $from_def | append $from_use
     } else {
-        where $it =~ '^(export )?def '
+        $source
+        | lines
+        | where $it =~ '^(export )?def '
         | extract-command-name
         | where $it starts-with 'main'
         | str replace 'main ' ''
@@ -962,6 +974,33 @@ export def capture-marker [
     } else {
         "\u{200C}\u{200B}"
     }
+}
+
+# Extract command names from `export use module.nu [commands]` pattern using AST
+#
+# When a module uses selective re-export like:
+#   export use commands.nu ["cmd1" "cmd2"]
+# This extracts the command names from the list.
+export def extract-export-use-commands []: string -> list<string> {
+    let tokens = ast --flatten $in | flatten span
+
+    # Find export use internal call
+    let export_use_matches = $tokens
+    | enumerate
+    | where { $in.item.content == 'export use' and $in.item.shape == 'shape_internalcall' }
+
+    if ($export_use_matches | is-empty) { return [] }
+
+    let export_use_idx = $export_use_matches | first | get index
+
+    # Get tokens after export use: module path, then list with command names
+    # Pattern: [export use] [module.nu] [ [cmd1] [cmd2] ... ]
+    # shape_string tokens inside shape_list are the command names
+    $tokens
+    | skip ($export_use_idx + 2)  # Skip "export use" and module path
+    | where shape == 'shape_string'
+    | get content
+    | each { str trim -c '"' }
 }
 
 # Complete AST output by filling gaps with synthetic tokens

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -1024,6 +1024,7 @@ export def extract-exported-commands []: string -> list<string> {
             | where shape == 'shape_string'
             | get content
             | str trim -c '"'
+            | str trim -c "'"
         }
     }
     | flatten

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -1112,16 +1112,10 @@ export def split-statements []: string -> table<statement: string, start: int, e
     for token in $tokens {
         # Track block depth
         # Handle blocks where { and } may be in same token (e.g., "{}" or "{ x }")
-        if $token.shape in ["shape_block" "shape_closure"] {
-            let has_open = $token.content | str contains "{"
-            let has_close = $token.content | str contains "}"
-            if $has_open and $has_close {
-                # Self-contained block like {} - no net depth change
-            } else if $has_open {
-                $depth = $depth + 1
-            } else if $has_close {
-                $depth = $depth - 1
-            }
+        if $token.shape in ["shape_block" "shape_closure" "shape_gap"] {
+            let opens = ($token.content | split row "{" | length) - 1
+            let closes = ($token.content | split row "}" | length) - 1
+            $depth = $depth + $opens - $closes
         }
 
         # Statement boundary at top level

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -348,7 +348,7 @@ export def find-examples []: string -> table<original: string, code: string, res
                 let open_char = $first_token.content
                 # Find matching close by tracking bracket depth
                 let close_token = $result_tokens | skip 1
-                | reduce --fold {depth: 1, token: null} {|t, acc|
+                | reduce --fold {depth: 1 token: null} {|t, acc|
                     if $acc.token != null { $acc } else {
                         let new_depth = if $t.content == $open_char {
                             $acc.depth + 1
@@ -357,7 +357,7 @@ export def find-examples []: string -> table<original: string, code: string, res
                         } else {
                             $acc.depth
                         }
-                        if $new_depth == 0 { {depth: 0, token: $t} } else { {depth: $new_depth, token: null} }
+                        if $new_depth == 0 { {depth: 0 token: $t} } else { {depth: $new_depth token: null} }
                     }
                 }
                 $close_token.token.end
@@ -1010,7 +1010,7 @@ export def extract-exported-commands []: string -> list<string> {
 
     $tokens
     | enumerate
-    | where { $in.item.content in ['export def' 'export use'] }
+    | where item.content in ['export def' 'export use']
     | each {|match|
         let idx = $match.index
         if $match.item.content == 'export def' {

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -337,14 +337,38 @@ export def find-examples []: string -> table<original: string, code: string, res
         | where shape not-in ["shape_whitespace" "shape_newline"]
 
         let result_info = if ($after_block_meaningful | is-not-empty) and ($after_block_meaningful | first | get shape) == "shape_flag" and ($after_block_meaningful | first | get content) == "--result" {
-            # Has --result flag - get the value token (skip whitespace after flag)
+            # Has --result flag - get the value token(s) (skip whitespace after flag)
             let result_tokens = $after_block_meaningful | skip 1
             | where shape not-in ["shape_whitespace" "shape_newline"]
-            let result_value = $result_tokens | first
+            let first_token = $result_tokens | first
+
+            # For lists/records, find matching closing bracket
+            let end_byte = if $first_token.content == "[" or $first_token.content == "{" {
+                let close_char = if $first_token.content == "[" { "]" } else { "}" }
+                let open_char = $first_token.content
+                # Find matching close by tracking bracket depth
+                let close_token = $result_tokens | skip 1
+                | reduce --fold {depth: 1, token: null} {|t, acc|
+                    if $acc.token != null { $acc } else {
+                        let new_depth = if $t.content == $open_char {
+                            $acc.depth + 1
+                        } else if $t.content == $close_char {
+                            $acc.depth - 1
+                        } else {
+                            $acc.depth
+                        }
+                        if $new_depth == 0 { {depth: 0, token: $t} } else { {depth: $new_depth, token: null} }
+                    }
+                }
+                $close_token.token.end
+            } else {
+                $first_token.end
+            }
+
             {
                 has_result: true
-                end_byte: $result_value.end
-                result_line: $"} --result ($result_value.content)"
+                end_byte: $end_byte
+                result_line: "" # not used, kept for interface compatibility
             }
         } else {
             # No --result flag

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -162,26 +162,34 @@ export def 'extract-command-code' [
     }
 }
 
-# todo: `list-exported-commands` should be a completion for Nushell CLI
-
-export def 'list-exported-commands' [
+# List all exported definitions from a module file
+#
+# Finds commands from `export def` and `export use [...commands]` patterns.
+export def 'list-module-exports' [
     $path: path
-    --export # use only commands that are exported
-] {
-    let source = open $path -r
+]: nothing -> list<string> {
+    open $path -r
+    | extract-exported-commands
+    | replace-main-with-module-name $path
+    | if ($in | is-empty) {
+        print 'No command found'
+        return
+    } else { }
+}
 
-    if $export {
-        $source
-        | extract-exported-commands
-        | replace-main-with-module-name $path
-    } else {
-        $source
-        | lines
-        | where $it =~ '^(export )?def '
-        | extract-command-name
-        | where $it starts-with 'main'
-        | str replace 'main ' ''
-    }
+# List module's callable interface (main commands)
+#
+# Finds `def main` and `def 'main subcommand'` patterns - the commands
+# available when you `use` the module.
+export def 'list-module-interface' [
+    $path: path
+]: nothing -> list<string> {
+    open $path -r
+    | lines
+    | where $it =~ '^(export )?def '
+    | extract-command-name
+    | where $it starts-with 'main'
+    | str replace 'main ' ''
     | if ($in | is-empty) {
         print 'No command found'
         return

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -288,10 +288,12 @@ export def find-examples []: string -> table<original: string, code: string, res
     | enumerate
     | window 2
     | where {|pair|
-        ($pair.0.item.shape == "shape_gap" and ($pair.0.item.content | str ends-with "@")
-        and $pair.1.item.content == "example")
+        (
+            $pair.0.item.shape == "shape_gap" and ($pair.0.item.content | str ends-with "@")
+            and $pair.1.item.content == "example"
+        )
     }
-    | each { $in.1.index }  # Get index of "example" token
+    | each { $in.1.index } # Get index of "example" token
 
     if ($example_indices | is-empty) {
         return []
@@ -304,7 +306,7 @@ export def find-examples []: string -> table<original: string, code: string, res
         # Find block tokens (shape_block) - opening and closing braces
         let block_tokens = $remaining
         | enumerate
-        | where {|r| $r.item.shape == "shape_block"}
+        | where {|r| $r.item.shape == "shape_block" }
 
         if ($block_tokens | length) < 2 {
             # Malformed @example - skip
@@ -320,12 +322,12 @@ export def find-examples []: string -> table<original: string, code: string, res
 
         # Skip whitespace/newlines to find the flag
         let after_block_meaningful = $after_block
-        | where shape not-in ["shape_whitespace", "shape_newline"]
+        | where shape not-in ["shape_whitespace" "shape_newline"]
 
         let result_info = if ($after_block_meaningful | is-not-empty) and ($after_block_meaningful | first | get shape) == "shape_flag" and ($after_block_meaningful | first | get content) == "--result" {
             # Has --result flag - get the value token (skip whitespace after flag)
             let result_tokens = $after_block_meaningful | skip 1
-            | where shape not-in ["shape_whitespace", "shape_newline"]
+            | where shape not-in ["shape_whitespace" "shape_newline"]
             let result_value = $result_tokens | first
             {
                 has_result: true
@@ -348,8 +350,8 @@ export def find-examples []: string -> table<original: string, code: string, res
 
         # Extract original text from @ to end of result value
         # The @ may be at end of a gap that includes newlines (e.g., "\n\n@")
-        let at_token = $tokens | get ($idx - 1)  # The gap token containing @
-        let at_start = $at_token.end - 1  # @ is always the last char in the gap
+        let at_token = $tokens | get ($idx - 1) # The gap token containing @
+        let at_start = $at_token.end - 1 # @ is always the last char in the gap
         let original = $bytes | bytes at $at_start..<($result_info.end_byte) | decode utf8
 
         # Extract code from inside the block (between { and })
@@ -689,10 +691,10 @@ export def list-module-commands [
     }
     | each {|pair|
         let attr_token = $pair.1.item
-        let at_start = $pair.0.item.end - 1  # @ is last char in the gap
-        { caller: ('@' + ($attr_token.content | split row ' ' | first)), start: $at_start }
+        let at_start = $pair.0.item.end - 1 # @ is last char in the gap
+        {caller: ('@' + ($attr_token.content | split row ' ' | first)) start: $at_start}
     }
-    | insert end null  # attributes don't have scope ranges
+    | insert end null # attributes don't have scope ranges
 
     let defined_defs = $def_definitions
     | append $attribute_definitions
@@ -991,7 +993,7 @@ export def ast-complete []: string -> table {
     | where {|p| $p.0.end < $p.1.start }
     | each {|p|
         let content = $bytes | bytes at $p.0.end..<$p.1.start | decode utf8
-        {content: $content, start: $p.0.end, end: $p.1.start, shape: (classify-gap $content)}
+        {content: $content start: $p.0.end end: $p.1.start shape: (classify-gap $content)}
     }
 
     $tokens | select content start end shape | append $gaps | sort-by start
@@ -1045,7 +1047,7 @@ export def split-statements []: string -> table<statement: string, start: int, e
     for token in $tokens {
         # Track block depth
         # Handle blocks where { and } may be in same token (e.g., "{}" or "{ x }")
-        if $token.shape in ["shape_block", "shape_closure"] {
+        if $token.shape in ["shape_block" "shape_closure"] {
             let has_open = $token.content | str contains "{"
             let has_close = $token.content | str contains "}"
             if $has_open and $has_close {
@@ -1059,8 +1061,10 @@ export def split-statements []: string -> table<statement: string, start: int, e
 
         # Statement boundary at top level
         # Also check shape_gap that starts with newline (comments are bundled into gaps)
-        let is_boundary = ($token.shape in ["shape_semicolon", "shape_newline"]
-            or ($token.shape == "shape_gap" and ($token.content | str starts-with "\n")))
+        let is_boundary = (
+            $token.shape in ["shape_semicolon" "shape_newline"]
+            or ($token.shape == "shape_gap" and ($token.content | str starts-with "\n"))
+        )
         if $depth == 0 and $is_boundary {
             let stmt_text = $bytes | bytes at $stmt_start..<$token.start | decode utf8 | str trim
             if ($stmt_text | is-not-empty) {

--- a/dotnu/mod.nu
+++ b/dotnu/mod.nu
@@ -10,7 +10,8 @@ export use commands.nu [
     "extract-command-code"
     "filter-commands-with-no-tests"
     "generate-numd"
-    "list-exported-commands"
+    "list-module-exports"
+    "list-module-interface"
     "module-commands-code-to-record"
     "set-x"
 ]

--- a/tests/output-yaml/coverage-untested.yaml
+++ b/tests/output-yaml/coverage-untested.yaml
@@ -21,5 +21,9 @@
 # }
 # | to yaml
 public_api_count: 15
-tested_count: 15
-untested: []
+tested_count: 11
+untested:
+- list-module-interface
+- embed-add
+- embeds-capture-start
+- embeds-capture-stop

--- a/tests/output-yaml/coverage-untested.yaml
+++ b/tests/output-yaml/coverage-untested.yaml
@@ -20,6 +20,6 @@
 # untested: ($untested | get caller)
 # }
 # | to yaml
-public_api_count: 14
-tested_count: 14
+public_api_count: 15
+tested_count: 15
 untested: []

--- a/tests/output-yaml/coverage-untested.yaml
+++ b/tests/output-yaml/coverage-untested.yaml
@@ -21,9 +21,8 @@
 # }
 # | to yaml
 public_api_count: 15
-tested_count: 11
+tested_count: 12
 untested:
-- list-module-interface
 - embed-add
 - embeds-capture-start
 - embeds-capture-stop

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -390,7 +390,7 @@ def "embeds-update preserves script structure" [] {
 @test
 def "embeds-setup sets capture path in env" [] {
     # Test without --auto-commit to avoid git operations
-    let test_path = ($nu.temp-path | path join 'test-capture.nu')
+    let test_path = ($nu.temp-dir | path join 'test-capture.nu')
     embeds-setup $test_path
 
     assert equal $env.dotnu.embeds-capture-path $test_path
@@ -398,7 +398,7 @@ def "embeds-setup sets capture path in env" [] {
 
 @test
 def "embeds-setup adds .nu extension if missing" [] {
-    let test_path = ($nu.temp-path | path join 'test-capture')
+    let test_path = ($nu.temp-dir | path join 'test-capture')
     embeds-setup $test_path
 
     assert ($env.dotnu.embeds-capture-path | str ends-with '.nu')
@@ -622,7 +622,7 @@ def foo [] {}'
 @test
 def "execute-example runs simple expression" [] {
     # Create temp file for context
-    let temp = $nu.temp-path | path join 'test-execute-example.nu'
+    let temp = $nu.temp-dir | path join 'test-execute-example.nu'
     'export def dummy [] { 1 }' | save -f $temp
 
     let result = execute-example '1 + 1' $temp
@@ -632,7 +632,7 @@ def "execute-example runs simple expression" [] {
 
 @test
 def "execute-example returns error record on failure" [] {
-    let temp = $nu.temp-path | path join 'test-execute-example.nu'
+    let temp = $nu.temp-dir | path join 'test-execute-example.nu'
     'export def dummy [] { 1 }' | save -f $temp
 
     let result = execute-example 'nonexistent-command' $temp
@@ -642,7 +642,7 @@ def "execute-example returns error record on failure" [] {
 
 @test
 def "execute-example handles multiline result" [] {
-    let temp = $nu.temp-path | path join 'test-execute-example.nu'
+    let temp = $nu.temp-dir | path join 'test-execute-example.nu'
     'export def dummy [] { 1 }' | save -f $temp
 
     let result = execute-example '[1, 2, 3]' $temp
@@ -656,7 +656,7 @@ def "execute-example handles multiline result" [] {
 
 @test
 def "examples-update updates result values" [] {
-    let temp = $nu.temp-path | path join 'test-examples-update.nu'
+    let temp = $nu.temp-dir | path join 'test-examples-update.nu'
     '@example "add" { 1 + 1 } --result 0
 export def dummy [] { 1 }' | save -f $temp
 
@@ -668,7 +668,7 @@ export def dummy [] { 1 }' | save -f $temp
 
 @test
 def "examples-update handles multiple examples" [] {
-    let temp = $nu.temp-path | path join 'test-examples-update.nu'
+    let temp = $nu.temp-dir | path join 'test-examples-update.nu'
     '@example "first" { 1 + 1 } --result 0
 export def foo [] {}
 
@@ -683,7 +683,7 @@ export def bar [] {}' | save -f $temp
 
 @test
 def "examples-update preserves file when no examples" [] {
-    let temp = $nu.temp-path | path join 'test-examples-update.nu'
+    let temp = $nu.temp-dir | path join 'test-examples-update.nu'
     let content = 'export def foo [] { 1 }'
     $content | save -f $temp
 
@@ -696,7 +696,7 @@ def "examples-update preserves file when no examples" [] {
 def "examples-update preserves dollar signs in results" [] {
     # Test that $var references in result strings are not lost
     # (regression test for regex backreference bug)
-    let temp = $nu.temp-path | path join 'test-examples-dollar.nu'
+    let temp = $nu.temp-dir | path join 'test-examples-dollar.nu'
     '@example "test" { "has $a variable" } --result "old"
 export def dummy [] { 1 }' | save -f $temp
 

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -592,6 +592,29 @@ def foo [] {}'
     assert ($result | first | get code | str contains "let x = 1")
 }
 
+@test
+def "find-examples parses list result values" [] {
+    let input = "@example \"list\" { ['a' 'b'] } --result ['a' 'b']
+def foo [] {}"
+
+    let result = $input | find-examples
+
+    assert equal ($result | length) 1
+    # Verify the full list is captured, not just the opening bracket
+    assert ($result | first | get original | str contains "['a' 'b']")
+}
+
+@test
+def "find-examples parses record result values" [] {
+    let input = '@example "record" { {a: 1} } --result {a: 1}
+def foo [] {}'
+
+    let result = $input | find-examples
+
+    assert equal ($result | length) 1
+    assert ($result | first | get original | str contains "{a: 1}")
+}
+
 # =============================================================================
 # Tests for execute-example
 # =============================================================================
@@ -667,6 +690,20 @@ def "examples-update preserves file when no examples" [] {
     let result = examples-update $temp --echo
 
     assert equal $result $content
+}
+
+@test
+def "examples-update preserves dollar signs in results" [] {
+    # Test that $var references in result strings are not lost
+    # (regression test for regex backreference bug)
+    let temp = $nu.temp-path | path join 'test-examples-dollar.nu'
+    '@example "test" { "has $a variable" } --result "old"
+export def dummy [] { 1 }' | save -f $temp
+
+    let result = examples-update $temp --echo
+
+    # The result should contain the $a, not have it stripped
+    assert ($result | str contains '$a')
 }
 
 # split-statements tests

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -324,12 +324,12 @@ def "extract-command-code handles quoted command names" [] {
 }
 
 # =============================================================================
-# Tests for list-exported-commands
+# Tests for list-module-exports
 # =============================================================================
 
 @test
-def "list-exported-commands finds exported commands" [] {
-    let result = list-exported-commands tests/assets/b/example-mod1.nu --export
+def "list-module-exports finds exported commands" [] {
+    let result = list-module-exports tests/assets/b/example-mod1.nu
 
     # Should find exported commands
     assert ('lscustom' in $result)
@@ -339,8 +339,8 @@ def "list-exported-commands finds exported commands" [] {
 }
 
 @test
-def "list-exported-commands excludes non-exported when flag set" [] {
-    let result = list-exported-commands tests/assets/b/example-mod1.nu --export
+def "list-module-exports excludes non-exported" [] {
+    let result = list-module-exports tests/assets/b/example-mod1.nu
 
     # Private commands should not be in exported list
     assert ('sort-by-custom' not-in $result)

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -324,6 +324,36 @@ def "extract-command-code handles quoted command names" [] {
 }
 
 # =============================================================================
+# Tests for list-module-interface
+# =============================================================================
+
+@test
+def "list-module-interface finds main command" [] {
+    let result = list-module-interface tests/assets/b/example-mod1.nu
+
+    assert equal $result ['main']
+}
+
+@test
+def "list-module-interface returns null when no main" [] {
+    let result = list-module-interface tests/assets/b/example-mod2.nu
+
+    assert equal $result null
+}
+
+@test
+def "list-module-interface strips main prefix from subcommands" [] {
+    let temp = $nu.temp-dir | path join 'test-module-interface.nu'
+    "export def main [] {}\nexport def 'main sub1' [] {}\nexport def 'main sub2' [] {}" | save -f $temp
+
+    let result = list-module-interface $temp
+
+    assert ('main' in $result)
+    assert ('sub1' in $result)
+    assert ('sub2' in $result)
+}
+
+# =============================================================================
 # Tests for list-module-exports
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- **Refactor `list-exported-commands`** into two focused commands: `extract-exported-commands` (AST-based export detection) and `list-module-interface` / `list-module-exports`, replacing fragile regex patterns
- **Fix `split-statements`** to count braces correctly, handling `match` blocks and multi-brace tokens
- **Fix `examples-update`** to parse list/record result values (bracket depth tracking) and escape `$` to prevent regex backreference loss
- **Fix `extract-exported-commands`** to strip single quotes from `export use` entries
- **Add tests** for `list-module-interface` (3 tests) and update coverage fixture (was stale on main)
- **Chore**: Nushell style fixes, `$nu.temp-dir` migration, README formatting, regression tests

## Test plan

- [x] `nu toolkit.nu test` passes (72 passed, 0 failed)
- [ ] Verify `list-module-exports` and `list-module-interface` produce correct output on real modules
- [ ] Verify `examples-update` handles `$`-containing and list/record result values

🤖 Generated with [Claude Code](https://claude.com/claude-code)