### PR TITLE
Update nushell paths to reflect recent breaking changes

### DIFF
--- a/tests/nupm/utils/dirs.nu
+++ b/tests/nupm/utils/dirs.nu
@@ -8,7 +8,7 @@ export const DEFAULT_NUPM_CACHE = ($nu.default-config-dir
     | path join nupm cache)
 
 # Default temporary path for various nupm purposes
-export const DEFAULT_NUPM_TEMP = ($nu.temp-path | path join "nupm")
+export const DEFAULT_NUPM_TEMP = ($nu.temp-dir | path join "nupm")
 
 # Default registry
 export const DEFAULT_NUPM_REGISTRIES = {


### PR DESCRIPTION
## Summary

Nushell v0.110.0 introduced a breaking change: renamed `$nu.temp-path` to `$nu.temp-dir`.

This PR updates `dotnu`, renaming `$nu.temp-path` to `$nu.temp-dir` in `tests/nupm/utils/dirs.nu` for compatibility with the recent nushell release.