### PR TITLE
Reliability fixes

### DIFF
--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -222,9 +222,12 @@ export def 'embeds-update' [
     let prevent_second_replacement = " # to-not-be-replaced-again"
 
     $replacements
-    | reduce --fold $script {|it|
+    # Why: prepend a newline so a capture point on the very first line is anchored
+    # by "\n" on both sides like any interior line; without it the match silently no-ops
+    | reduce --fold ("\n" + $script) {|it|
         str replace ("\n" + $it.0 + "\n") ("\n" + $it.0 + $prevent_second_replacement + "\n" + $it.1 + "\n")
     }
+    | str replace -r '^\n' '' # strip the single leading newline added above
     | str replace -a $prevent_second_replacement ''
     | str replace -ar '\n{3,}' "\n\n"
     | str replace -r "\n*$" "\n"

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -4,6 +4,12 @@
 # Public API is controlled by mod.nu which selectively re-exports user-facing commands.
 # To make a command public, add it to the export list in mod.nu.
 
+# Regex matching a capture point: a pipeline line ending in `| print $in`.
+# Why: `find-capture-points` and `execute-and-parse-results` must agree on what a
+# capture point is — they are zipped together in `embeds-update`, so any disagreement
+# misaligns outputs against the wrong lines.
+const capture_point = '\|\s*print\s+\$in\s*$'
+
 # Check .nu module files to determine which commands depend on other commands.
 @example 'Analyze command dependencies in a module' {
     dotnu dependencies ...(glob tests/assets/module-say/say/*.nu)
@@ -962,7 +968,7 @@ export def execute-and-parse-results [
     | each {
         if $in !~ '^\s*#' {
             # don't search for `print $in` inside of commented lines
-            str replace -r '\| *print +\$in *' '| embed-in-script'
+            str replace -r $capture_point '| embed-in-script'
         } else { }
     }
     | prepend $embed_in_script_src
@@ -982,7 +988,7 @@ export def execute-and-parse-results [
 # Finds lines where embed-in-script is used in the script
 export def find-capture-points [] {
     lines
-    | where $it !~ '^\s*#' and $it =~ '\|\s?print \$in *$'
+    | where $it !~ '^\s*#' and $it =~ $capture_point
 }
 
 # Removes annotation lines starting with "# => " from the script

--- a/dotnu/commands.nu
+++ b/dotnu/commands.nu
@@ -4,8 +4,6 @@
 # Public API is controlled by mod.nu which selectively re-exports user-facing commands.
 # To make a command public, add it to the export list in mod.nu.
 
-use std/iter scan
-
 # Check .nu module files to determine which commands depend on other commands.
 @example 'Analyze command dependencies in a module' {
     dotnu dependencies ...(glob tests/assets/module-say/say/*.nu)
@@ -805,8 +803,11 @@ export def 'module-commands-code-to-record' [
     }
     | merge (
         $in.command
-        | scan --noinit null {|i acc|
-            if $i == null { $acc } else { $i }
+        # Why: std `scan` with a null seed now errors — its internal `generate` treats
+        # null as "no initial value". Forward-fill the last non-null name manually instead.
+        | reduce --fold [] {|i acc|
+            let prev = $acc | last
+            $acc | append (if $i == null { $prev } else { $i })
         }
         | wrap command
     )

--- a/tests/assets/dotnu-capture-clean.nu
+++ b/tests/assets/dotnu-capture-clean.nu
@@ -7,9 +7,9 @@
 # And and this is the link on dotnu module:
 # https://github.com/nushell-prophet/dotnu
 
-ls | sort-by modified -r | last 2 | print $in
+40 + 2 | print $in
 
-random int | print $in
+[[name type]; [foo file] [bar dir]] | print $in
 
 'Say hello to the core team of the Nushell'
 | str replace 'Nushell' 'Best shell'

--- a/tests/assets/dotnu-capture-updated.nu
+++ b/tests/assets/dotnu-capture-updated.nu
@@ -6,16 +6,16 @@
 # And and this is the link on dotnu module:
 # https://github.com/nushell-prophet/dotnu
 
-ls | sort-by modified -r | last 2 | print $in
-# => ╭───┬──────────────────────────────┬──────┬───────┬────────────╮
-# => │ # │             name             │ type │ size  │  modified  │
-# => ├───┼──────────────────────────────┼──────┼───────┼────────────┤
-# => │ 0 │ set-x-demo.nu                │ file │  41 B │ a year ago │
-# => │ 1 │ parsing-pipe-in-docstring.nu │ file │ 923 B │ a year ago │
-# => ╰───┴──────────────────────────────┴──────┴───────┴────────────╯
+40 + 2 | print $in
+# => 42
 
-random int | print $in
-# => 2835756183325042638
+[[name type]; [foo file] [bar dir]] | print $in
+# => ╭───┬──────┬──────╮
+# => │ # │ name │ type │
+# => ├───┼──────┼──────┤
+# => │ 0 │ foo  │ file │
+# => │ 1 │ bar  │ dir  │
+# => ╰───┴──────┴──────╯
 
 'Say hello to the core team of the Nushell'
 | str replace 'Nushell' 'Best shell'

--- a/tests/assets/dotnu-capture.nu
+++ b/tests/assets/dotnu-capture.nu
@@ -5,16 +5,13 @@
 # And and this is the link on dotnu module:
 # https://github.com/nushell-prophet/dotnu
 
-ls | sort-by modified -r | last 2 | print $in
-# => ╭─#─┬──────name──────┬─type─┬─size──┬───modified───╮
-# => │ 0 │ zzz_md_backups │ dir  │ 160 B │ 2 months ago │
-# => │ 1 │ test.nu        │ file │  45 B │ 3 months ago │
-# => ╰─#─┴──────name──────┴─type─┴─size──┴───modified───╯
+40 + 2 | print $in
+# => 0
 
-random int | print $in
-# => 6970240173764648305
+[[name type]; [foo file] [bar dir]] | print $in
+# => stale
 
 'Say hello to the core team of the Nushell'
 | str replace 'Nushell' 'Best shell'
 | print $in
-# => Say hello to the core team of the Best shell
+# => WRONG

--- a/tests/output-yaml/coverage-untested.nuon
+++ b/tests/output-yaml/coverage-untested.nuon
@@ -13,16 +13,21 @@
 # | where caller in $public_api
 # | select caller
 # 
-# # Output as yaml
+# # Why: serialize as nuon, not yaml — `to yaml`'s list indentation
+# # changed between nushell versions and drifted this snapshot on
+# # identical data. nuon compares the parsed structure stably.
 # {
 # public_api_count: ($public_api | length)
 # tested_count: (($public_api | length) - ($untested | length))
 # untested: ($untested | get caller)
 # }
-# | to yaml
-public_api_count: 15
-tested_count: 12
-untested:
-- embed-add
-- embeds-capture-start
-- embeds-capture-stop
+# | to nuon --indent 2
+{
+  public_api_count: 15,
+  tested_count: 12,
+  untested: [
+    embed-add,
+    embeds-capture-start,
+    embeds-capture-stop
+  ]
+}

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -394,6 +394,15 @@ def "embeds-update updates embeds in piped script" [] {
 }
 
 @test
+def "embeds-update annotates a capture point on the first line" [] {
+    # No leading newline before the capture point
+    let script = "'hello' | str upcase | print $in\n"
+    let result = $script | embeds-update
+
+    assert ($result =~ '# => HELLO')
+}
+
+@test
 def "embeds-update preserves script structure" [] {
     let script = "# comment\n\n1 + 1 | print $in\n\n# another"
     let result = $script | embeds-update

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -103,7 +103,7 @@ export def 'main test-integration' [
             }
         )
         (
-            run-snapshot-test 'coverage' ([tests output-yaml coverage-untested.yaml] | path join) {
+            run-snapshot-test 'coverage' ([tests output-yaml coverage-untested.nuon] | path join) {
                 # Public API from mod.nu
                 let public_api = open ([dotnu mod.nu] | path join)
                 | lines
@@ -119,13 +119,15 @@ export def 'main test-integration' [
                 | where caller in $public_api
                 | select caller
 
-                # Output as yaml
+                # Why: serialize as nuon, not yaml — `to yaml`'s list indentation
+                # changed between nushell versions and drifted this snapshot on
+                # identical data. nuon compares the parsed structure stably.
                 {
                     public_api_count: ($public_api | length)
                     tested_count: (($public_api | length) - ($untested | length))
                     untested: ($untested | get caller)
                 }
-                | to yaml
+                | to nuon --indent 2
             }
         )
     ]

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -177,9 +177,17 @@ def run-snapshot-test [name: string output_file: string command_src: closure] {
         $command_text + (char nl) + (do $command_src)
         | save -f $output_file
 
-        # Check git diff to determine status
-        let diff_result = do { ^git diff --quiet $output_file } | complete
-        let status = if $diff_result.exit_code == 0 { 'passed' } else { 'changed' }
+        # Check git diff to determine status.
+        # Why: `git diff` ignores untracked files, so a brand-new snapshot would
+        # report 'passed' without ever being compared to a baseline. Treat an
+        # untracked file as 'changed' so it surfaces and `--update` stages it.
+        let tracked = do { ^git ls-files --error-unmatch $output_file } | complete | get exit_code | $in == 0
+        let status = if not $tracked {
+            'changed'
+        } else {
+            let diff_result = do { ^git diff --quiet $output_file } | complete
+            if $diff_result.exit_code == 0 { 'passed' } else { 'changed' }
+        }
 
         {type: 'integration' name: $name status: $status file: $output_file}
     } catch {|err|


### PR DESCRIPTION
Running `nu toolkit.nu test` on a clean checkout was not green: 2 unit tests failed outright and 2 snapshot tests drifted on every run. This branch fixes the root causes — one real breakage, one latent bug, and three test-honesty issues — and gets the suite to **74 passed, 0 failed, 0 changed**.

### Bugs

- **`module-commands-code-to-record` broke on nushell 0.113** (`47422c4`). It forward-filled command names with `scan --noinit null`; std `scan` now delegates to `generate`, which rejects a `null` seed as "no initial value", so the command and its two unit tests errored out. Since dotnu can't patch std, the fix forward-fills with a `reduce` instead and drops the now-dead `use std/iter scan` import.

- **Capture-point regex had two disagreeing definitions** (`5c884ee`). The detector (`find-capture-points`) matched `\|\s?print \$in *$` while the rewriter (`execute-and-parse-results`) matched `\| *print +\$in *`. They diverged on real inputs (two spaces after `|`, mid-pipeline `| print $in | bar`), and since `embeds-update` zips the two together, a disagreement silently embeds output against the wrong line. Replaced with one module-level `const capture_point` used by both, anchored to end-of-line.

### Test honesty

- **New snapshots reported false `passed`** (`f1eac60`). `run-snapshot-test` used `git diff --quiet`, which ignores untracked files, so a brand-new snapshot's first run never compared against anything. Now an untracked output is `changed` so it surfaces and `--update` stages it.

- **embeds-update snapshot was nondeterministic** (`850b4e6`). Its fixture contained `random int` and `ls | sort-by modified` — random and filesystem-dependent — so it could never match. Replaced those with deterministic equivalents (`40 + 2`, a literal table) while keeping full round-trip coverage (scalar capture, multi-line table capture, multi-line pipeline). The input `# =>` values are intentionally wrong, so a silent no-op or skipped capture point leaves the wrong value and fails the snapshot — keeping the end-to-end test honest under determinism.

- **coverage snapshot drifted on serializer formatting** (`b429bdb`). It compared `to yaml` text, whose list indentation changed between nushell versions on identical data. Switched to nuon so the snapshot compares parsed structure, not yaml's incidental formatting.
